### PR TITLE
Add feature computation service, model, and UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,31 @@
+from flask import Flask, render_template, request, redirect, url_for
+import json
+
+from models import FeatureConfig, SessionLocal, init_db
+
+app = Flask(__name__)
+
+# Ensure tables exist
+def get_session():
+    init_db()
+    return SessionLocal()
+
+
+@app.route("/features", methods=["GET", "POST"])
+def features():
+    session = get_session()
+    if request.method == "POST":
+        name = request.form["name"]
+        config_raw = request.form["config"]
+        config = json.loads(config_raw)
+        feature = FeatureConfig(name=name, config=config)
+        session.add(feature)
+        session.commit()
+        return redirect(url_for("features"))
+
+    features = session.query(FeatureConfig).all()
+    return render_template("features.html", features=features)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, JSON, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///features.db"
+
+engine = create_engine(DATABASE_URL, echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+Base = declarative_base()
+
+
+class FeatureConfig(Base):
+    __tablename__ = "feature_configs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    config = Column(JSON, nullable=False)
+
+
+def init_db() -> None:
+    """Create database tables."""
+    Base.metadata.create_all(bind=engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+SQLAlchemy
+pandas

--- a/services/features.py
+++ b/services/features.py
@@ -1,0 +1,65 @@
+import pandas as pd
+from typing import Dict, Any
+
+
+def compute_features(df: pd.DataFrame, config: Dict[str, Any]) -> pd.DataFrame:
+    """Apply feature operations defined in *config* to *df*.
+
+    Parameters
+    ----------
+    df:
+        Source data as a pandas DataFrame.
+    config:
+        Dictionary describing feature operations. Expected format::
+
+            {
+                "operations": [
+                    {
+                        "operation": "sum",
+                        "columns": ["a", "b"],
+                        "new_column": "a_plus_b"
+                    },
+                    {
+                        "operation": "ratio",
+                        "numerator": "a",
+                        "denominator": "b",
+                        "new_column": "a_div_b"
+                    }
+                ]
+            }
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame including new feature columns.
+    """
+    operations = config.get("operations", [])
+
+    for op in operations:
+        name = op.get("new_column")
+        if not name:
+            raise ValueError("Each operation requires a 'new_column' field")
+
+        op_type = op.get("operation")
+        if op_type == "sum":
+            cols = op.get("columns", [])
+            df[name] = df[cols].sum(axis=1)
+        elif op_type == "difference":
+            cols = op.get("columns", [])
+            if len(cols) != 2:
+                raise ValueError("'difference' requires exactly two columns")
+            df[name] = df[cols[0]] - df[cols[1]]
+        elif op_type == "ratio":
+            num = op.get("numerator")
+            den = op.get("denominator")
+            df[name] = df[num] / df[den]
+        elif op_type == "mean":
+            cols = op.get("columns", [])
+            df[name] = df[cols].mean(axis=1)
+        else:
+            expr = op.get("expression")
+            if expr is None:
+                raise ValueError(f"Unsupported operation: {op_type}")
+            df[name] = df.eval(expr)
+
+    return df

--- a/templates/features.html
+++ b/templates/features.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Feature Configurations</title>
+</head>
+<body>
+  <h1>Create Feature Set</h1>
+  <form method="post" action="/features">
+    <label for="name">Name:</label>
+    <input type="text" id="name" name="name" required>
+
+    <label for="config">Config (JSON):</label>
+    <textarea id="config" name="config" rows="10" cols="60" required>{"operations": []}</textarea>
+
+    <button type="submit">Save</button>
+  </form>
+
+  {% if features %}
+    <h2>Existing Feature Sets</h2>
+    <ul>
+    {% for f in features %}
+      <li>{{ f.name }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement compute_features utility to build derived columns from a config
- persist feature configurations via new FeatureConfig SQLAlchemy model
- provide Flask form to create and save feature sets

## Testing
- `python -m py_compile app.py models.py services/features.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f3f8795083298aa86eb9d664f0f5