### PR TITLE
Add basic SQL migration system

### DIFF
--- a/migrations/001_create_user_databases.sql
+++ b/migrations/001_create_user_databases.sql
@@ -1,4 +1,4 @@
--- Schema for storing per-user database credentials
+-- Initial schema for tracking per-user databases
 CREATE TABLE IF NOT EXISTS user_databases (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 APScheduler
 pandas
 requests
+pymysql

--- a/services/migrations.py
+++ b/services/migrations.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pymysql
+
+
+def apply_migrations(conn: pymysql.connections.Connection, migrations_dir: Path) -> None:
+    """Apply SQL migrations located in ``migrations_dir``.
+
+    Each ``.sql`` file is executed once and tracked in the ``schema_migrations``
+    table. Files are processed in alphabetical order.
+    """
+    migrations_dir = migrations_dir.resolve()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version VARCHAR(255) PRIMARY KEY,
+                applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        cur.execute("SELECT version FROM schema_migrations")
+        applied = {row[0] for row in cur.fetchall()}
+
+        for path in sorted(migrations_dir.glob("*.sql")):
+            version = path.stem
+            if version in applied:
+                continue
+            statements = [s.strip() for s in path.read_text().split(";") if s.strip()]
+            for statement in statements:
+                cur.execute(statement)
+            cur.execute(
+                "INSERT INTO schema_migrations (version) VALUES (%s)",
+                (version,),
+            )
+    conn.commit()


### PR DESCRIPTION
## Summary
- add lightweight SQL migration runner
- run migrations during user registration and track in schema_migrations
- move user database table schema into migration file
- include pymysql dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5f53c60888329a237dac0b98040ec