### PR TITLE
Add financial model playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Economical Data Service
 
-This project provides a simple Flask application that fetches a time series from a remote source, caches it on disk and serves the cached data through a small API. A background scheduler refreshes the cache once per day.
+This project has evolved into a small **financial model playground** built
+with Flask and a minimal HTML front‑end. It demonstrates a complete
+workflow for experimenting with economic time series:
+
+1. **Collect real market data** using the Yahoo Finance API.
+2. **Transform the raw series** into modelling variables such as
+   percentage returns.
+3. **Fit a simple autoregressive model** to the processed data.
+4. **Validate the model** on recent observations to check how well it
+   captures reality.
+
+The original API for serving cached time series is still available and a
+new web form at `/model` drives the modelling pipeline.
 
 ## Setup
 
@@ -33,7 +45,9 @@ This project provides a simple Flask application that fetches a time series from
    python app.py
    ```
 
-   The service exposes a health check at `/` and cached data under `/api/data/<series_id>`.
+   The service exposes a health check at `/`, cached data under
+   `/api/data/<series_id>` and an interactive modelling playground at
+   `/model`.
 
 ## Development
 

--- a/app.py
+++ b/app.py
@@ -7,10 +7,12 @@ from flask import Flask
 from dotenv import load_dotenv
 
 from routes.data import bp as data_bp
+from routes.model import bp as model_bp
 from services.data_ingestion import cache_series, fetch_series
 
 app = Flask(__name__)
 app.register_blueprint(data_bp)
+app.register_blueprint(model_bp)
 
 load_dotenv()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pandas
 requests
 pymysql
 python-dotenv
+scikit-learn
+yfinance

--- a/routes/model.py
+++ b/routes/model.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from flask import Blueprint, render_template, request
+
+from services.data_ingestion import fetch_market_data
+from services.modeling import fit_and_validate
+
+bp = Blueprint("model", __name__, url_prefix="/model")
+
+
+@bp.get("/")
+def form() -> str:
+    """Render a simple form for model fitting."""
+
+    return render_template("model.html")
+
+
+@bp.post("/")
+def run_model() -> str:
+    """Execute the modelling pipeline and display results."""
+
+    symbol = request.form.get("symbol", "")
+    start = request.form.get("start", "2000-01-01")
+    end = request.form.get("end", "")
+
+    df = fetch_market_data(symbol, start, end or None)
+    result = fit_and_validate(df)
+
+    return render_template("model.html", result=result, symbol=symbol)
+

--- a/services/data_ingestion.py
+++ b/services/data_ingestion.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pandas as pd
 import requests
+import yfinance as yf
 
 
 def fetch_series(source: str, symbol: str, start: str, end: str) -> pd.DataFrame:
@@ -36,6 +37,33 @@ def fetch_series(source: str, symbol: str, start: str, end: str) -> pd.DataFrame
     if "date" in df.columns:
         df["date"] = pd.to_datetime(df["date"])
         df = df.set_index("date")
+    return df
+
+
+def fetch_market_data(symbol: str, start: str, end: str | None = None) -> pd.DataFrame:
+    """Fetch market data using the Yahoo Finance API.
+
+    Parameters
+    ----------
+    symbol: str
+        Ticker symbol understood by Yahoo Finance.
+    start: str
+        Start date in ``YYYY-MM-DD`` format.
+    end: str
+        End date in ``YYYY-MM-DD`` format.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with a ``value`` column containing the adjusted close
+        prices indexed by date.
+    """
+
+    data = yf.download(symbol, start=start, end=end, progress=False)
+    if data.empty:
+        return pd.DataFrame(columns=["value"])
+    df = data[["Adj Close"]].rename(columns={"Adj Close": "value"})
+    df.index.name = "date"
     return df
 
 

--- a/services/modeling.py
+++ b/services/modeling.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_squared_error
+
+
+@dataclass
+class ModelResult:
+    """Container for fitted model parameters and validation metric."""
+
+    coef: float
+    intercept: float
+    rmse: float
+
+
+def _prepare_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert raw price series into modelling features.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with a ``value`` column representing the price series.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with percentage returns and a one day lag feature.
+    """
+
+    data = df.copy()
+    data["return"] = data["value"].pct_change()
+    data["lag1"] = data["return"].shift(1)
+    data = data.dropna()
+    return data
+
+
+def fit_and_validate(df: pd.DataFrame, holdout: int = 5) -> ModelResult:
+    """Fit a simple autoregressive model and validate on a holdout set.
+
+    The function uses the previous day's return to predict the next day's
+    return via linear regression. The last ``holdout`` observations are used
+    for validation and the root mean squared error (RMSE) is reported.
+    """
+
+    features = _prepare_features(df)
+    if len(features) <= holdout:
+        raise ValueError("Not enough data for the requested holdout size")
+
+    train = features.iloc[:-holdout]
+    test = features.iloc[-holdout:]
+
+    model = LinearRegression()
+    model.fit(train[["lag1"]], train["return"])
+
+    preds = model.predict(test[["lag1"]])
+    rmse = float(mean_squared_error(test["return"], preds, squared=False))
+
+    return ModelResult(
+        coef=float(model.coef_[0]),
+        intercept=float(model.intercept_),
+        rmse=rmse,
+    )
+
+
+__all__ = ["fit_and_validate", "ModelResult"]
+

--- a/templates/model.html
+++ b/templates/model.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Financial Model Playground</title>
+  </head>
+  <body>
+    <h1>Financial Model Playground</h1>
+    <form method="post">
+      <label>Symbol: <input name="symbol" required></label><br>
+      <label>Start Date (YYYY-MM-DD): <input name="start" required></label><br>
+      <label>End Date (YYYY-MM-DD): <input name="end"></label><br>
+      <button type="submit">Run Model</button>
+    </form>
+
+    {% if result %}
+    <h2>Results for {{ symbol }}</h2>
+    <ul>
+      <li>Coefficient: {{ result.coef }}</li>
+      <li>Intercept: {{ result.intercept }}</li>
+      <li>RMSE: {{ result.rmse }}</li>
+    </ul>
+    {% endif %}
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- add Yahoo Finance ingestion and simple autoregressive modelling pipeline
- expose a `/model` web form for fitting and validating the model
- document end-to-end workflow in README

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6561ada3c8329a88ca53d78d2951c