### PR TITLE
Add AR model endpoint and visualization

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 
 from routes.data import bp as data_bp
 from routes.model import bp as model_bp
-from services.data_ingestion import cache_series, fetch_series
+from services.data_ingestion import cache_series, fetch_remote_series
 
 app = Flask(__name__)
 app.register_blueprint(data_bp)
@@ -25,7 +25,7 @@ scheduler = BackgroundScheduler()
 
 
 def fetch_and_cache() -> None:
-    df = fetch_series(SOURCE_URL, SYMBOL, START_DATE, END_DATE)
+    df = fetch_remote_series(SOURCE_URL, SYMBOL, START_DATE, END_DATE)
     cache_series(SYMBOL, df)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pymysql
 python-dotenv
 scikit-learn
 yfinance
+statsmodels
+matplotlib

--- a/services/modeling.py
+++ b/services/modeling.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Tuple
 
 import pandas as pd
 from sklearn.linear_model import LinearRegression
 from sklearn.metrics import mean_squared_error
+from statsmodels.tsa.ar_model import AutoReg
 
 
 @dataclass
@@ -67,4 +68,32 @@ def fit_and_validate(df: pd.DataFrame, holdout: int = 5) -> ModelResult:
 
 
 __all__ = ["fit_and_validate", "ModelResult"]
+
+
+def fit_ar_model(series: pd.Series) -> Tuple[Dict[str, float], pd.Series]:
+    """Fit an autoregressive (AR(1)) model to a price series.
+
+    Parameters
+    ----------
+    series:
+        Time series of prices indexed by date.
+
+    Returns
+    -------
+    Tuple[Dict[str, float], pandas.Series]
+        Dictionary of model parameters and a series of in-sample predictions
+        aligned with the input series index.
+    """
+
+    clean = series.dropna()
+    model = AutoReg(clean, lags=1, old_names=False)
+    fitted = model.fit()
+
+    params = {key: float(val) for key, val in fitted.params.items()}
+    preds = fitted.fittedvalues
+    preds.name = "prediction"
+    return params, preds
+
+
+__all__.append("fit_ar_model")
 

--- a/templates/model_result.html
+++ b/templates/model_result.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Model Result</title>
+  </head>
+  <body>
+    <h1>Results for {{ symbol }}</h1>
+    <img src="data:image/png;base64,{{ plot_data }}" alt="Actual vs Predicted">
+    <h2>Parameters</h2>
+    <ul>
+    {% for name, value in params.items() %}
+      <li>{{ name }}: {{ value }}</li>
+    {% endfor %}
+    </ul>
+    <p><a href="{{ url_for('model.form') }}">Back</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- fetch price series from Yahoo Finance via new `fetch_series`
- fit autoregressive model and return parameters and predictions
- add `/model` endpoint with form submission and result page showing actual vs predicted chart

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a659d63eac83299d99538706ceeedb