### PR TITLE
Add modular AR/VAR models and feature builder

### DIFF
--- a/routes/model.py
+++ b/routes/model.py
@@ -7,8 +7,8 @@ from flask import Blueprint, render_template, request
 
 import matplotlib.pyplot as plt
 
-from services.data_ingestion import fetch_series
-from services.modeling import fit_ar_model
+from services.data_ingestion import build_features, fetch_series
+from services.modeling import ARModel, VARModel
 
 bp = Blueprint("model", __name__, url_prefix="/model")
 
@@ -27,9 +27,20 @@ def run_model() -> str:
     symbol = request.form.get("symbol", "")
     start = request.form.get("start", "2000-01-01")
     end = request.form.get("end", "")
+    model_type = request.form.get("model_type", "ar")
+    indicator_opts = request.form.getlist("indicators")
 
     df = fetch_series(symbol, start, end or None)
-    params, preds = fit_ar_model(df["value"])
+    features = build_features(df["value"], indicator_opts)
+
+    if model_type == "var" and features.shape[1] > 1:
+        model = VARModel()
+        model.fit(features)
+        preds = model.predict()["value"]
+    else:
+        model = ARModel()
+        model.fit(df["value"])
+        preds = model.predict()
 
     fig, ax = plt.subplots()
     df["value"].plot(ax=ax, label="Actual")
@@ -43,10 +54,17 @@ def run_model() -> str:
     plot_data = base64.b64encode(buf.getvalue()).decode("ascii")
     plt.close(fig)
 
+    latest_indicators = (
+        features.drop(columns=["value"]).iloc[-1].to_dict()
+        if not features.empty
+        else {}
+    )
+
     return render_template(
         "model_result.html",
         symbol=symbol,
-        params=params,
+        params=model.params,
+        indicators=latest_indicators,
         plot_data=plot_data,
     )
 

--- a/services/data_ingestion.py
+++ b/services/data_ingestion.py
@@ -100,3 +100,29 @@ def cache_series(series_id: str, df: pd.DataFrame) -> Path:
     file_path = cache_dir / f"{series_id}.json"
     df.to_json(file_path, orient="records", date_format="iso")
     return file_path
+
+
+def build_features(series: pd.Series, options: list[str]) -> pd.DataFrame:
+    """Compute derived indicators for a price series.
+
+    Parameters
+    ----------
+    series:
+        Raw price series.
+    options:
+        List of indicator names to compute. Supported values are
+        ``"moving_average"`` and ``"return"``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing the original ``value`` column along with any
+        requested indicators.
+    """
+
+    df = pd.DataFrame({"value": series})
+    if "moving_average" in options:
+        df["moving_average"] = series.rolling(window=5).mean()
+    if "return" in options:
+        df["return"] = series.pct_change()
+    return df.dropna()

--- a/templates/model.html
+++ b/templates/model.html
@@ -10,17 +10,19 @@
       <label>Symbol: <input name="symbol" required></label><br>
       <label>Start Date (YYYY-MM-DD): <input name="start" required></label><br>
       <label>End Date (YYYY-MM-DD): <input name="end"></label><br>
+      <label>Model Type:
+        <select name="model_type">
+          <option value="ar">AR</option>
+          <option value="var">VAR</option>
+        </select>
+      </label><br>
+      <fieldset>
+        <legend>Indicators</legend>
+        <label><input type="checkbox" name="indicators" value="moving_average">Moving Average</label>
+        <label><input type="checkbox" name="indicators" value="return">Return</label>
+      </fieldset>
       <button type="submit">Run Model</button>
     </form>
-
-    {% if result %}
-    <h2>Results for {{ symbol }}</h2>
-    <ul>
-      <li>Coefficient: {{ result.coef }}</li>
-      <li>Intercept: {{ result.intercept }}</li>
-      <li>RMSE: {{ result.rmse }}</li>
-    </ul>
-    {% endif %}
   </body>
 </html>
 

--- a/templates/model_result.html
+++ b/templates/model_result.html
@@ -13,6 +13,14 @@
       <li>{{ name }}: {{ value }}</li>
     {% endfor %}
     </ul>
+    {% if indicators %}
+    <h2>Indicators</h2>
+    <ul>
+    {% for name, value in indicators.items() %}
+      <li>{{ name }}: {{ value }}</li>
+    {% endfor %}
+    </ul>
+    {% endif %}
     <p><a href="{{ url_for('model.form') }}">Back</a></p>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Introduce abstract `BaseModel` with concrete `ARModel` and `VARModel` implementations.
- Implement `build_features` to compute moving average and return indicators.
- Extend model route and templates to select model type and display indicators.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a65b2deebc8329aec85f23d87bc9c8