### PR TITLE
Add categories blueprint and template

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,11 +8,13 @@ from dotenv import load_dotenv
 
 from routes.data import bp as data_bp
 from routes.model import bp as model_bp
+from routes.categories import bp as categories_bp
 from services.data_ingestion import cache_series, fetch_remote_series
 
 app = Flask(__name__)
 app.register_blueprint(data_bp)
 app.register_blueprint(model_bp)
+app.register_blueprint(categories_bp)
 
 load_dotenv()
 

--- a/routes/categories.py
+++ b/routes/categories.py
@@ -6,6 +6,7 @@ This module defines static category information that can be imported from
 routes and templates without executing any I/O on import.
 """
 
+from flask import Blueprint, render_template
 from typing import Dict, List, TypedDict
 
 
@@ -44,3 +45,13 @@ def get_categories() -> List[Category]:
     """Return all category definitions."""
 
     return list(CATEGORIES.values())
+
+
+bp = Blueprint("categories", __name__, url_prefix="/categories")
+
+
+@bp.get("/")
+def index() -> str:
+    """Render the categories page."""
+
+    return render_template("categories.html", categories=get_categories())

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Categories</title>
+  </head>
+  <body>
+    <h1>Categories</h1>
+    {% for category in categories %}
+      <section>
+        <h2>{{ category.name }}</h2>
+        <p>{{ category.description }}</p>
+        <h3>Deterministic Models</h3>
+        <ul>
+          {% for model in category.deterministic_examples %}
+            <li>{{ model }}</li>
+          {% endfor %}
+        </ul>
+        <h3>Stochastic Models</h3>
+        <ul>
+          {% for model in category.stochastic_examples %}
+            <li>{{ model }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endfor %}
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add categories blueprint with endpoint rendering categories
- register categories blueprint in app
- display category descriptions and model lists

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6603bcae48329a6a936dc7d2fb6bf