### PR TITLE
Add categories navbar to model templates

### DIFF
--- a/templates/model.html
+++ b/templates/model.html
@@ -5,6 +5,9 @@
     <title>Financial Model Playground</title>
   </head>
   <body>
+    <nav>
+      <a href="{{ url_for('categories.index') }}">Categories</a>
+    </nav>
     <h1>Financial Model Playground</h1>
     <form method="post">
       <label>Symbol: <input name="symbol" required></label><br>

--- a/templates/model_result.html
+++ b/templates/model_result.html
@@ -5,6 +5,9 @@
     <title>Model Result</title>
   </head>
   <body>
+    <nav>
+      <a href="{{ url_for('categories.index') }}">Categories</a>
+    </nav>
     <h1>Results for {{ symbol }}</h1>
     <img src="data:image/png;base64,{{ plot_data }}" alt="Actual vs Predicted">
     <h2>Parameters</h2>


### PR DESCRIPTION
## Summary
- Add simple navigation bar linking to categories page in model form and result templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6619e884883299348b79d83bc06ca