### PR TITLE
Add search and filter UI for categories

### DIFF
--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const searchInput = document.getElementById('search');
+  const checkboxes = document.querySelectorAll('.filter-checkbox');
+  const cards = document.querySelectorAll('.category-card');
+
+  function applyFilters() {
+    const query = searchInput.value.toLowerCase();
+    const active = Array.from(checkboxes)
+      .filter(cb => cb.checked)
+      .map(cb => cb.value);
+
+    cards.forEach(card => {
+      const text = card.innerText.toLowerCase();
+      const adaptability = card.dataset.adaptability;
+      const matchesQuery = text.includes(query);
+      const matchesAdaptability = active.length === 0 || active.includes(adaptability);
+      card.style.display = matchesQuery && matchesAdaptability ? '' : 'none';
+    });
+  }
+
+  searchInput.addEventListener('input', applyFilters);
+  checkboxes.forEach(cb => cb.addEventListener('change', applyFilters));
+});

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -6,23 +6,39 @@
   </head>
   <body>
     <h1>Categories</h1>
-    {% for category in categories %}
-      <section>
-        <h2>{{ category.name }}</h2>
-        <p>{{ category.description }}</p>
-        <h3>Deterministic Models</h3>
-        <ul>
-          {% for model in category.deterministic_examples %}
-            <li>{{ model }}</li>
-          {% endfor %}
-        </ul>
-        <h3>Stochastic Models</h3>
-        <ul>
-          {% for model in category.stochastic_examples %}
-            <li>{{ model }}</li>
-          {% endfor %}
-        </ul>
-      </section>
-    {% endfor %}
+    <div id="controls">
+      <input type="text" id="search" placeholder="Search categories..." />
+      <div id="filters">
+        {% for level in categories | map(attribute='adaptability') | unique %}
+          <label>
+            <input type="checkbox" class="filter-checkbox" value="{{ level }}" />
+            {{ level }}
+          </label>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div id="category-container">
+      {% for category in categories %}
+        <section class="category-card" data-adaptability="{{ category.adaptability }}">
+          <h2>{{ category.name }}</h2>
+          <p>{{ category.description }}</p>
+          <h3>Deterministic Models</h3>
+          <ul>
+            {% for model in category.deterministic_examples %}
+              <li>{{ model }}</li>
+            {% endfor %}
+          </ul>
+          <h3>Stochastic Models</h3>
+          <ul>
+            {% for model in category.stochastic_examples %}
+              <li>{{ model }}</li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endfor %}
+    </div>
+
+    <script src="{{ url_for('static', filename='js/filter.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add search input and adaptability checkbox filters to category page
- implement client-side filter logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6631969e48329b50aa14bdca9921e