### PR TITLE
Add category icons and display on categories page

### DIFF
--- a/static/icons/economics.svg
+++ b/static/icons/economics.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 17l6-6 4 4 8-8"/>
+  <path d="M14 7h7v7"/>
+</svg>

--- a/static/icons/finance.svg
+++ b/static/icons/finance.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 1v22"/>
+  <path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/>
+</svg>

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -8,6 +8,7 @@
     <h1>Categories</h1>
     {% for category in categories %}
       <section>
+        <img src="{{ url_for('static', filename='icons/' ~ category.name|lower ~ '.svg') }}" alt="{{ category.name }} icon">
         <h2>{{ category.name }}</h2>
         <p>{{ category.description }}</p>
         <h3>Deterministic Models</h3>


### PR DESCRIPTION
## Summary
- add economics and finance SVG icons in new static/icons directory
- show category icons on categories page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a66316db608329bcfc0b699d2f5fb8