### PR TITLE
Add related model links to categories

### DIFF
--- a/routes/categories.py
+++ b/routes/categories.py
@@ -19,6 +19,7 @@ class Category(TypedDict):
     stochastic_examples: List[str]
     adaptability: str
     related_categories: List[str]
+    links: Dict[str, str]
 
 
 CATEGORIES: Dict[str, Category] = {
@@ -29,6 +30,9 @@ CATEGORIES: Dict[str, Category] = {
         "stochastic_examples": ["market volatility", "interest rate shocks"],
         "adaptability": "High",
         "related_categories": ["finance", "statistics"],
+        "links": {
+            "GDP growth": "/categories/finance#stock-price-simulation",
+        },
     },
     "finance": {
         "name": "Finance",
@@ -37,6 +41,9 @@ CATEGORIES: Dict[str, Category] = {
         "stochastic_examples": ["stock price simulation", "risk models"],
         "adaptability": "Medium",
         "related_categories": ["economics"],
+        "links": {
+            "stock price simulation": "/categories/economics#gdp-growth",
+        },
     },
 }
 
@@ -55,3 +62,10 @@ def index() -> str:
     """Render the categories page."""
 
     return render_template("categories.html", categories=get_categories())
+
+
+@bp.get("/<path:subpath>")
+def anchor(subpath: str) -> str:
+    """Allow category path segments for anchor links."""
+
+    return index()

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -7,19 +7,33 @@
   <body>
     <h1>Categories</h1>
     {% for category in categories %}
-      <section>
+      <section id="{{ category.name|lower|replace(' ', '-') }}">
         <h2>{{ category.name }}</h2>
         <p>{{ category.description }}</p>
         <h3>Deterministic Models</h3>
         <ul>
           {% for model in category.deterministic_examples %}
-            <li>{{ model }}</li>
+            <li id="{{ model|lower|replace(' ', '-') }}">
+              {{ model }}
+              {% if category.links and model in category.links %}
+                {% set href = category.links[model] %}
+                {% set anchor = href.split('#')[-1].replace('-', ' ').title() %}
+                <div><a href="{{ href }}">Related: {{ anchor }}</a></div>
+              {% endif %}
+            </li>
           {% endfor %}
         </ul>
         <h3>Stochastic Models</h3>
         <ul>
           {% for model in category.stochastic_examples %}
-            <li>{{ model }}</li>
+            <li id="{{ model|lower|replace(' ', '-') }}">
+              {{ model }}
+              {% if category.links and model in category.links %}
+                {% set href = category.links[model] %}
+                {% set anchor = href.split('#')[-1].replace('-', ' ').title() %}
+                <div><a href="{{ href }}">Related: {{ anchor }}</a></div>
+              {% endif %}
+            </li>
           {% endfor %}
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- extend category metadata with cross-model `links`
- render related model links and anchors in categories template
- handle category path segments for anchor navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6631b8fbc8329a7245a985478c4ee