### PR TITLE
Add global tooltip support and mark abbreviations

### DIFF
--- a/static/js/tooltips.js
+++ b/static/js/tooltips.js
@@ -1,0 +1,9 @@
+// Initialize tooltips for elements with a title attribute
+// Requires tippy.js to be loaded on the page.
+// This script will upgrade any element that has a `title` attribute
+// into a nicer tooltip while preserving accessibility.
+document.addEventListener('DOMContentLoaded', function () {
+  if (window.tippy) {
+    tippy('[title]');
+  }
+});

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -1,28 +1,23 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Categories</title>
-  </head>
-  <body>
-    <h1>Categories</h1>
-    {% for category in categories %}
-      <section>
-        <h2>{{ category.name }}</h2>
-        <p>{{ category.description }}</p>
-        <h3>Deterministic Models</h3>
-        <ul>
-          {% for model in category.deterministic_examples %}
-            <li>{{ model }}</li>
-          {% endfor %}
-        </ul>
-        <h3>Stochastic Models</h3>
-        <ul>
-          {% for model in category.stochastic_examples %}
-            <li>{{ model }}</li>
-          {% endfor %}
-        </ul>
-      </section>
-    {% endfor %}
-  </body>
-</html>
+{% extends "layout.html" %}
+{% block title %}Categories{% endblock %}
+{% block content %}
+<h1>Categories</h1>
+{% for category in categories %}
+  <section>
+    <h2>{{ category.name }}</h2>
+    <p>{{ category.description }}</p>
+    <h3>Deterministic Models</h3>
+    <ul>
+      {% for model in category.deterministic_examples %}
+        <li>{{ model | replace('GDP', '<abbr title="Gross Domestic Product">GDP</abbr>') | safe }}</li>
+      {% endfor %}
+    </ul>
+    <h3>Stochastic Models</h3>
+    <ul>
+      {% for model in category.stochastic_examples %}
+        <li>{{ model }}</li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endfor %}
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}Economical{% endblock %}</title>
+    <script src="https://unpkg.com/@popperjs/core@2"></script>
+    <script src="https://unpkg.com/tippy.js@6"></script>
+    <script src="{{ url_for('static', filename='js/tooltips.js') }}"></script>
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/templates/model.html
+++ b/templates/model.html
@@ -1,31 +1,25 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Financial Model Playground</title>
-  </head>
-  <body>
-    <nav>
-      <a href="{{ url_for('categories.index') }}">Categories</a>
-    </nav>
-    <h1>Financial Model Playground</h1>
-    <form method="post">
-      <label>Symbol: <input name="symbol" required></label><br>
-      <label>Start Date (YYYY-MM-DD): <input name="start" required></label><br>
-      <label>End Date (YYYY-MM-DD): <input name="end"></label><br>
-      <label>Model Type:
-        <select name="model_type">
-          <option value="ar">AR</option>
-          <option value="var">VAR</option>
-        </select>
-      </label><br>
-      <fieldset>
-        <legend>Indicators</legend>
-        <label><input type="checkbox" name="indicators" value="moving_average">Moving Average</label>
-        <label><input type="checkbox" name="indicators" value="return">Return</label>
-      </fieldset>
-      <button type="submit">Run Model</button>
-    </form>
-  </body>
-</html>
-
+{% extends "layout.html" %}
+{% block title %}Financial Model Playground{% endblock %}
+{% block content %}
+<nav>
+  <a href="{{ url_for('categories.index') }}">Categories</a>
+</nav>
+<h1>Financial Model Playground</h1>
+<form method="post">
+  <label>Symbol: <input name="symbol" required></label><br>
+  <label>Start Date (YYYY-MM-DD): <input name="start" required></label><br>
+  <label>End Date (YYYY-MM-DD): <input name="end"></label><br>
+  <label>Model Type:
+    <select name="model_type">
+      <option value="ar"><abbr title="AutoRegressive">AR</abbr></option>
+      <option value="var"><abbr title="Vector AutoRegressive">VAR</abbr></option>
+    </select>
+  </label><br>
+  <fieldset>
+    <legend>Indicators</legend>
+    <label><input type="checkbox" name="indicators" value="moving_average">Moving Average</label>
+    <label><input type="checkbox" name="indicators" value="return">Return</label>
+  </fieldset>
+  <button type="submit">Run Model</button>
+</form>
+{% endblock %}

--- a/templates/model_result.html
+++ b/templates/model_result.html
@@ -1,29 +1,24 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Model Result</title>
-  </head>
-  <body>
-    <nav>
-      <a href="{{ url_for('categories.index') }}">Categories</a>
-    </nav>
-    <h1>Results for {{ symbol }}</h1>
-    <img src="data:image/png;base64,{{ plot_data }}" alt="Actual vs Predicted">
-    <h2>Parameters</h2>
-    <ul>
-    {% for name, value in params.items() %}
-      <li>{{ name }}: {{ value }}</li>
-    {% endfor %}
-    </ul>
-    {% if indicators %}
-    <h2>Indicators</h2>
-    <ul>
-    {% for name, value in indicators.items() %}
-      <li>{{ name }}: {{ value }}</li>
-    {% endfor %}
-    </ul>
-    {% endif %}
-    <p><a href="{{ url_for('model.form') }}">Back</a></p>
-  </body>
-</html>
+{% extends "layout.html" %}
+{% block title %}Model Result{% endblock %}
+{% block content %}
+<nav>
+  <a href="{{ url_for('categories.index') }}">Categories</a>
+</nav>
+<h1>Results for {{ symbol }}</h1>
+<img src="data:image/png;base64,{{ plot_data }}" alt="Actual vs Predicted">
+<h2>Parameters</h2>
+<ul>
+{% for name, value in params.items() %}
+  <li>{{ name }}: {{ value }}</li>
+{% endfor %}
+</ul>
+{% if indicators %}
+<h2>Indicators</h2>
+<ul>
+{% for name, value in indicators.items() %}
+  <li>{{ name }}: {{ value }}</li>
+{% endfor %}
+</ul>
+{% endif %}
+<p><a href="{{ url_for('model.form') }}">Back</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `tooltips.js` using tippy.js to enhance title-based tooltips
- Introduce shared layout loading tooltip script across pages
- Wrap technical abbreviations such as AR/VAR and GDP in `<abbr>` tags for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6631d3c3c832985c197bc37b3b0f5