### PR TITLE
Add model category links to results

### DIFF
--- a/routes/model.py
+++ b/routes/model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import io
 
-from flask import Blueprint, render_template, request
+from flask import Blueprint, render_template, request, url_for
 
 import matplotlib.pyplot as plt
 
@@ -29,6 +29,14 @@ def run_model() -> str:
     end = request.form.get("end", "")
     model_type = request.form.get("model_type", "ar")
     indicator_opts = request.form.getlist("indicators")
+
+    category_map = {"ar": "time-series", "var": "time-series"}
+    category_slug = category_map.get(model_type)
+    category_url = (
+        url_for("categories.anchor", subpath=category_slug)
+        if category_slug
+        else url_for("categories.index")
+    )
 
     df = fetch_series(symbol, start, end or None)
     features = build_features(df["value"], indicator_opts)
@@ -66,5 +74,6 @@ def run_model() -> str:
         params=model.params,
         indicators=latest_indicators,
         plot_data=plot_data,
+        category_url=category_url,
     )
 

--- a/templates/model_result.html
+++ b/templates/model_result.html
@@ -7,6 +7,9 @@
   <body>
     <nav>
       <a href="{{ url_for('categories.index') }}">Categories</a>
+      {% if category_url %}
+      <a href="{{ category_url }}">See Category</a>
+      {% endif %}
     </nav>
     <h1>Results for {{ symbol }}</h1>
     <img src="data:image/png;base64,{{ plot_data }}" alt="Actual vs Predicted">


### PR DESCRIPTION
## Summary
- Determine model category from selected model type and generate category URL
- Display a "See Category" link on model results page

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6656f2448832990855bdef56c8f02