### PR TITLE
Configure static file caching

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,8 @@ from routes.model import bp as model_bp
 from routes.categories import bp as categories_bp
 from services.data_ingestion import cache_series, fetch_remote_series
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder="static", static_url_path="/static")
+app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 31536000
 app.register_blueprint(data_bp)
 app.register_blueprint(model_bp)
 app.register_blueprint(categories_bp)

--- a/routes/categories.py
+++ b/routes/categories.py
@@ -45,6 +45,39 @@ CATEGORIES: Dict[str, Category] = {
             "stock price simulation": "/categories/economics#gdp-growth",
         },
     },
+    "statistics": {
+        "name": "Statistics",
+        "description": "Techniques for data analysis and inference.",
+        "deterministic_examples": ["mean", "median"],
+        "stochastic_examples": ["bootstrap", "bayesian inference"],
+        "adaptability": "High",
+        "related_categories": ["economics", "finance"],
+        "links": {
+            "mean": "/categories/economics#gdp-growth",
+        },
+    },
+    "machine_learning": {
+        "name": "Machine Learning",
+        "description": "Algorithms that learn patterns from data.",
+        "deterministic_examples": ["linear regression", "decision trees"],
+        "stochastic_examples": ["neural networks", "random forests"],
+        "adaptability": "High",
+        "related_categories": ["statistics"],
+        "links": {
+            "linear regression": "/categories/statistics#mean",
+        },
+    },
+    "forecasting": {
+        "name": "Forecasting",
+        "description": "Predictive models for future events.",
+        "deterministic_examples": ["moving average", "exponential smoothing"],
+        "stochastic_examples": ["ARIMA", "Monte Carlo simulation"],
+        "adaptability": "Medium",
+        "related_categories": ["economics", "statistics"],
+        "links": {
+            "ARIMA": "/categories/machine_learning#neural-networks",
+        },
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- configure Flask app to serve `/static` with long-lived cache headers
- extend categories metadata to provide five complete definitions

## Testing
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('app_main','app.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
app = module.app
client = app.test_client()
resp = client.get('/static/js/filter.js')
print(resp.status_code)
print(resp.headers.get('Cache-Control'))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66b54232c8329b0074553a87603a5