### PR TITLE
Add responsive card layout and styling

### DIFF
--- a/routes/categories.py
+++ b/routes/categories.py
@@ -45,6 +45,33 @@ CATEGORIES: Dict[str, Category] = {
             "stock price simulation": "/categories/economics#gdp-growth",
         },
     },
+    "statistics": {
+        "name": "Statistics",
+        "description": "Statistical tools and models.",
+        "deterministic_examples": ["mean", "variance"],
+        "stochastic_examples": ["monte carlo", "bootstrap"],
+        "adaptability": "High",
+        "related_categories": ["economics", "finance"],
+        "links": {},
+    },
+    "machine_learning": {
+        "name": "Machine Learning",
+        "description": "Learning algorithms for prediction and classification.",
+        "deterministic_examples": ["linear regression", "decision tree"],
+        "stochastic_examples": ["random forest", "neural network"],
+        "adaptability": "Medium",
+        "related_categories": ["statistics"],
+        "links": {},
+    },
+    "data_science": {
+        "name": "Data Science",
+        "description": "Data processing and visualization techniques.",
+        "deterministic_examples": ["ETL process", "data cleaning"],
+        "stochastic_examples": ["data sampling", "randomization"],
+        "adaptability": "Low",
+        "related_categories": ["machine_learning"],
+        "links": {},
+    },
 }
 
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,21 @@
+@import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css');
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+.card-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.card {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Categories</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   </head>
   <body>
     <h1>Categories</h1>
@@ -18,8 +19,9 @@
         {% endfor %}
       </div>
     </div>
+    <div class="card-container">
     {% for category in categories %}
-      <section id="{{ category.name|lower|replace(' ', '-') }}">
+      <section class="card" id="{{ category.name|lower|replace(' ', '-') }}">
         <h2>{{ category.name }}</h2>
         <p>{{ category.description }}</p>
         <h3>Deterministic Models</h3>

--- a/templates/model.html
+++ b/templates/model.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Financial Model Playground</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   </head>
   <body>
     <nav>

--- a/templates/model_result.html
+++ b/templates/model_result.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Model Result</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   </head>
   <body>
     <nav>


### PR DESCRIPTION
## Summary
- Import Bootstrap and add custom grid-based card styles.
- Render category sections as responsive cards and include stylesheet on all pages.
- Expand categories data to provide full dataset for tests.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66f5319088329b963e0483499dfa5