### PR TITLE
Improve accessibility and complete category metadata

### DIFF
--- a/routes/categories.py
+++ b/routes/categories.py
@@ -45,6 +45,33 @@ CATEGORIES: Dict[str, Category] = {
             "stock price simulation": "/categories/economics#gdp-growth",
         },
     },
+    "statistics": {
+        "name": "Statistics",
+        "description": "General statistical tools used across domains.",
+        "deterministic_examples": ["linear regression", "hypothesis testing"],
+        "stochastic_examples": ["monte carlo methods", "bootstrap"],
+        "adaptability": "High",
+        "related_categories": ["economics", "machine-learning"],
+        "links": {},
+    },
+    "machine-learning": {
+        "name": "Machine Learning",
+        "description": "Data-driven algorithms for pattern finding and prediction.",
+        "deterministic_examples": ["decision tree", "support vector machine"],
+        "stochastic_examples": ["random forest", "neural network"],
+        "adaptability": "High",
+        "related_categories": ["statistics", "optimization"],
+        "links": {},
+    },
+    "optimization": {
+        "name": "Optimization",
+        "description": "Approaches for selecting best outcomes under constraints.",
+        "deterministic_examples": ["linear programming", "gradient descent"],
+        "stochastic_examples": ["simulated annealing", "genetic algorithms"],
+        "adaptability": "Low",
+        "related_categories": ["machine-learning"],
+        "links": {},
+    },
 }
 
 

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -5,52 +5,59 @@
     <title>Categories</title>
   </head>
   <body>
-    <h1>Categories</h1>
-    
-    <div id="controls">
-      <input type="text" id="search" placeholder="Search categories..." />
-      <div id="filters">
-        {% for level in categories | map(attribute='adaptability') | unique %}
-          <label>
-            <input type="checkbox" class="filter-checkbox" value="{{ level }}" />
-            {{ level }}
-          </label>
-        {% endfor %}
-      </div>
-    </div>
-    {% for category in categories %}
-      <section id="{{ category.name|lower|replace(' ', '-') }}">
-        <h2>{{ category.name }}</h2>
-        <p>{{ category.description }}</p>
-        <h3>Deterministic Models</h3>
-        <ul>
-          {% for model in category.deterministic_examples %}
-            <li id="{{ model|lower|replace(' ', '-') }}">
-              {{ model }}
-              {% if category.links and model in category.links %}
-                {% set href = category.links[model] %}
-                {% set anchor = href.split('#')[-1].replace('-', ' ').title() %}
-                <div><a href="{{ href }}">Related: {{ anchor }}</a></div>
-              {% endif %}
-            </li>
+    <nav aria-label="Main navigation">
+      <a href="{{ url_for('model.form') }}">Model Playground</a>
+    </nav>
+    <main>
+      <h1>Categories</h1>
+
+      <form id="controls" role="search" aria-label="Category filters">
+        <label for="search">Search categories</label>
+        <input type="text" id="search" placeholder="Search categories..." />
+        <fieldset id="filters">
+          <legend>Filter by adaptability</legend>
+          {% for level in categories | map(attribute='adaptability') | unique %}
+            <label>
+              <input type="checkbox" class="filter-checkbox" value="{{ level }}" />
+              {{ level }}
+            </label>
           {% endfor %}
-        </ul>
-        <h3>Stochastic Models</h3>
-        <ul>
-          {% for model in category.stochastic_examples %}
-            <li id="{{ model|lower|replace(' ', '-') }}">
-              {{ model }}
-              {% if category.links and model in category.links %}
-                {% set href = category.links[model] %}
-                {% set anchor = href.split('#')[-1].replace('-', ' ').title() %}
-                <div><a href="{{ href }}">Related: {{ anchor }}</a></div>
-              {% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </section>
-    {% endfor %}
-    </div>
+        </fieldset>
+      </form>
+      {% for category in categories %}
+        <section id="{{ category.name|lower|replace(' ', '-') }}" class="category-card" data-adaptability="{{ category.adaptability }}">
+          <h2>{{ category.name }}</h2>
+          <img src="{{ url_for('static', filename='icons/' + category.name|lower|replace(' ', '-') + '.svg') }}" alt="{{ category.name }} icon" onerror="this.style.display='none'">
+          <p>{{ category.description }}</p>
+          <h3>Deterministic Models</h3>
+          <ul>
+            {% for model in category.deterministic_examples %}
+              <li id="{{ model|lower|replace(' ', '-') }}">
+                {{ model }}
+                {% if category.links and model in category.links %}
+                  {% set href = category.links[model] %}
+                  {% set anchor = href.split('#')[-1].replace('-', ' ').title() %}
+                  <div><a href="{{ href }}">Related: {{ anchor }}</a></div>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+          <h3>Stochastic Models</h3>
+          <ul>
+            {% for model in category.stochastic_examples %}
+              <li id="{{ model|lower|replace(' ', '-') }}">
+                {{ model }}
+                {% if category.links and model in category.links %}
+                  {% set href = category.links[model] %}
+                  {% set anchor = href.split('#')[-1].replace('-', ' ').title() %}
+                  <div><a href="{{ href }}">Related: {{ anchor }}</a></div>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endfor %}
+    </main>
 
     <script src="{{ url_for('static', filename='js/filter.js') }}"></script>
 

--- a/templates/model.html
+++ b/templates/model.html
@@ -5,9 +5,10 @@
     <title>Financial Model Playground</title>
   </head>
   <body>
-    <nav>
+    <nav aria-label="Main navigation">
       <a href="{{ url_for('categories.index') }}">Categories</a>
     </nav>
+    <main>
     <h1>Financial Model Playground</h1>
     <form method="post">
       <label>Symbol: <input name="symbol" required></label><br>
@@ -26,6 +27,7 @@
       </fieldset>
       <button type="submit">Run Model</button>
     </form>
+    </main>
   </body>
 </html>
 

--- a/templates/model_result.html
+++ b/templates/model_result.html
@@ -5,14 +5,15 @@
     <title>Model Result</title>
   </head>
   <body>
-    <nav>
+    <nav aria-label="Main navigation">
       <a href="{{ url_for('categories.index') }}">Categories</a>
       {% if category_url %}
       <a href="{{ category_url }}">See Category</a>
       {% endif %}
     </nav>
+    <main>
     <h1>Results for {{ symbol }}</h1>
-    <img src="data:image/png;base64,{{ plot_data }}" alt="Actual vs Predicted">
+    <img src="data:image/png;base64,{{ plot_data }}" alt="Actual vs Predicted chart">
     <h2>Parameters</h2>
     <ul>
     {% for name, value in params.items() %}
@@ -28,5 +29,6 @@
     </ul>
     {% endif %}
     <p><a href="{{ url_for('model.form') }}">Back</a></p>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add ARIA-labelled navigation and main regions across templates
- label search and filters for keyboard access and supply icon alt text
- populate missing category definitions to satisfy tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66db041588329b1dc8170bb21a14c