### PR TITLE
Cache category metadata retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ All category metadata lives in [`routes/categories.py`](routes/categories.py)
 within the `CATEGORIES` dictionary. Each entry defines the name,
 description, example models and optional links to related topics.
 
+The helper that exposes these definitions uses a small in-process LRU
+cache to avoid rebuilding the list for every request. This lightweight
+approach can be swapped out for a more robust cache if the data grows or
+becomes dynamic.
+
 To add a category, extend `CATEGORIES` with a new definition following the
 existing structure. Icons for categories can be placed in
 [`static/icons/`](static/icons) (create the directory if necessary) using the

--- a/routes/categories.py
+++ b/routes/categories.py
@@ -6,6 +6,7 @@ This module defines static category information that can be imported from
 routes and templates without executing any I/O on import.
 """
 
+from functools import lru_cache
 from flask import Blueprint, render_template
 from typing import Dict, List, TypedDict
 
@@ -75,8 +76,14 @@ CATEGORIES: Dict[str, Category] = {
 }
 
 
+@lru_cache()
 def get_categories() -> List[Category]:
-    """Return all category definitions."""
+    """Return all category definitions.
+
+    The result is cached in-process with :func:`functools.lru_cache` to
+    avoid rebuilding the category list on each request. This lightweight
+    approach can be replaced with a more robust cache if necessary.
+    """
 
     return list(CATEGORIES.values())
 


### PR DESCRIPTION
## Summary
- cache category metadata using `functools.lru_cache`
- document lightweight cache and potential future replacement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6720ce5bc8329a6d1ba63253396d8