### PR TITLE
Add scaffolding for core screens and ERD-backed models

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,12 +9,26 @@ from dotenv import load_dotenv
 from routes.data import bp as data_bp
 from routes.model import bp as model_bp
 from routes.categories import bp as categories_bp
+from routes.auth import bp as auth_bp
+from routes.datasets import bp as datasets_bp
+from routes.projects import bp as projects_bp
+from routes.dashboards import bp as dashboards_bp
+from routes.community import bp as community_bp
+from routes.notifications import bp as notifications_bp
+from routes.admin import bp as admin_bp
 from services.data_ingestion import cache_series, fetch_remote_series
 
 app = Flask(__name__)
 app.register_blueprint(data_bp)
 app.register_blueprint(model_bp)
 app.register_blueprint(categories_bp)
+app.register_blueprint(auth_bp)
+app.register_blueprint(datasets_bp)
+app.register_blueprint(projects_bp)
+app.register_blueprint(dashboards_bp)
+app.register_blueprint(community_bp)
+app.register_blueprint(notifications_bp)
+app.register_blueprint(admin_bp)
 
 load_dotenv()
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,131 @@
+"""Dataclasses representing core ERD entities.
+
+These models are derived from the sitemap and ERD mapping
+at ``docs/sitemap_erd.md`` to provide a lightweight
+schema scaffold for future database integration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional
+
+
+@dataclass
+class User:
+    id: int
+    name: str
+    email: str
+    affiliation: Optional[str] = None
+    role: str = "user"
+    preferences_json: Dict[str, object] = field(default_factory=dict)
+    password_hash: str = ""
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class Team:
+    id: int
+    name: str
+    description: Optional[str] = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class Dataset:
+    id: int
+    name: str
+    description: str
+    tags: List[str] = field(default_factory=list)
+    visibility: str = "private"
+    owner_id: int = 0
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class DatasetVersion:
+    dataset_id: int
+    origin: str
+    version_tag: str
+    changelog: str = ""
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class DatasetUsage:
+    dataset_id: int
+    views: int = 0
+    downloads: int = 0
+    api_calls: int = 0
+    last_accessed: Optional[datetime] = None
+
+
+@dataclass
+class Model:
+    id: int
+    name: str
+    description: str
+    model_type: str
+    owner_id: int
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class Project:
+    id: int
+    name: str
+    description: str
+    owner_id: int
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class Dashboard:
+    id: int
+    name: str
+    description: str
+    owner_id: int
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class MapView:
+    id: int
+    name: str
+    description: str
+    layer_config: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class Post:
+    id: int
+    content: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class Comment:
+    id: int
+    post_id: int
+    content: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class Like:
+    id: int
+    post_id: int
+    user_id: int
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class Notification:
+    id: int
+    message: str
+    type: str
+    is_read: bool = False
+    created_at: datetime = field(default_factory=datetime.utcnow)

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,0 +1,11 @@
+"""Admin dashboard routes."""
+
+from flask import Blueprint, render_template
+
+bp = Blueprint("admin", __name__, url_prefix="/admin")
+
+
+@bp.get("/")
+def dashboard():
+    """Render the admin dashboard."""
+    return render_template("admin/dashboard.html")

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,0 +1,23 @@
+"""Authentication and account related routes."""
+
+from flask import Blueprint, render_template
+
+bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+@bp.get("/login")
+def login():
+    """Render the login page."""
+    return render_template("auth/login.html")
+
+
+@bp.get("/signup")
+def signup():
+    """Render the sign up page."""
+    return render_template("auth/signup.html")
+
+
+@bp.get("/password-reset")
+def password_reset():
+    """Render the password reset page."""
+    return render_template("auth/password_reset.html")

--- a/routes/community.py
+++ b/routes/community.py
@@ -1,0 +1,11 @@
+"""Community feed routes."""
+
+from flask import Blueprint, render_template
+
+bp = Blueprint("community", __name__, url_prefix="/community")
+
+
+@bp.get("/")
+def feed():
+    """Render the global community feed."""
+    return render_template("community/feed.html")

--- a/routes/dashboards.py
+++ b/routes/dashboards.py
@@ -1,0 +1,17 @@
+"""Dashboard catalog and detail views."""
+
+from flask import Blueprint, render_template
+
+bp = Blueprint("dashboards", __name__, url_prefix="/dashboards")
+
+
+@bp.get("/")
+def catalog():
+    """List available dashboards."""
+    return render_template("dashboards/catalog.html")
+
+
+@bp.get("/<int:dashboard_id>")
+def detail(dashboard_id: int):
+    """Show dashboard details."""
+    return render_template("dashboards/detail.html", dashboard_id=dashboard_id)

--- a/routes/datasets.py
+++ b/routes/datasets.py
@@ -1,0 +1,17 @@
+"""Dataset catalog and detail views."""
+
+from flask import Blueprint, render_template
+
+bp = Blueprint("datasets", __name__, url_prefix="/datasets")
+
+
+@bp.get("/")
+def catalog():
+    """List available datasets."""
+    return render_template("datasets/catalog.html")
+
+
+@bp.get("/<int:dataset_id>")
+def detail(dataset_id: int):
+    """Show dataset details."""
+    return render_template("datasets/detail.html", dataset_id=dataset_id)

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -1,0 +1,11 @@
+"""User notification routes."""
+
+from flask import Blueprint, render_template
+
+bp = Blueprint("notifications", __name__, url_prefix="/notifications")
+
+
+@bp.get("/")
+def list_notifications():
+    """List notifications for the current user."""
+    return render_template("notifications/list.html")

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -1,0 +1,17 @@
+"""Project catalog and detail views."""
+
+from flask import Blueprint, render_template
+
+bp = Blueprint("projects", __name__, url_prefix="/projects")
+
+
+@bp.get("/")
+def catalog():
+    """List available projects."""
+    return render_template("projects/catalog.html")
+
+
+@bp.get("/<int:project_id>")
+def detail(project_id: int):
+    """Show project details."""
+    return render_template("projects/detail.html", project_id=project_id)

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Admin Dashboard</h1>
+<p>Admin tools will appear here.</p>
+{% endblock %}

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+  <label for="email">Email</label>
+  <input id="email" type="email" name="email" required>
+  <label for="password">Password</label>
+  <input id="password" type="password" name="password" required>
+  <label><input type="checkbox" name="remember"> Remember me</label>
+  <button type="submit">Log in</button>
+</form>
+<p><a href="/auth/password-reset">Forgot password?</a></p>
+<p><a href="/auth/signup">Create new account</a></p>
+{% endblock %}

--- a/templates/auth/password_reset.html
+++ b/templates/auth/password_reset.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Password Reset</h1>
+<form method="post">
+  <label for="email">Email</label>
+  <input id="email" type="email" name="email" required>
+  <button type="submit">Send Reset Link</button>
+</form>
+<p><a href="/auth/login">Back to login</a></p>
+{% endblock %}

--- a/templates/auth/signup.html
+++ b/templates/auth/signup.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Sign Up</h1>
+<form method="post">
+  <label for="name">Name</label>
+  <input id="name" type="text" name="name" required>
+  <label for="email">Email</label>
+  <input id="email" type="email" name="email" required>
+  <label for="password">Password</label>
+  <input id="password" type="password" name="password" required>
+  <button type="submit">Create Account</button>
+</form>
+<p><a href="/auth/login">Already have an account?</a></p>
+{% endblock %}

--- a/templates/community/feed.html
+++ b/templates/community/feed.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Community Feed</h1>
+<p>Latest posts will appear here.</p>
+{% endblock %}

--- a/templates/dashboards/catalog.html
+++ b/templates/dashboards/catalog.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dashboard Catalog</h1>
+<p>List of dashboards will appear here.</p>
+{% endblock %}

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dashboard {{ dashboard_id }}</h1>
+<p>Dashboard details will appear here.</p>
+{% endblock %}

--- a/templates/datasets/catalog.html
+++ b/templates/datasets/catalog.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dataset Catalog</h1>
+<p>List of datasets will appear here.</p>
+{% endblock %}

--- a/templates/datasets/detail.html
+++ b/templates/datasets/detail.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dataset {{ dataset_id }}</h1>
+<p>Dataset details will appear here.</p>
+{% endblock %}

--- a/templates/notifications/list.html
+++ b/templates/notifications/list.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Notifications</h1>
+<p>User notifications will appear here.</p>
+{% endblock %}

--- a/templates/projects/catalog.html
+++ b/templates/projects/catalog.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Project Catalog</h1>
+<p>List of projects will appear here.</p>
+{% endblock %}

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Project {{ project_id }}</h1>
+<p>Project details will appear here.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- scaffold dataclasses for users, datasets, models, projects, dashboards, maps, community posts, and notifications
- add blueprints for auth, datasets, projects, dashboards, community, notifications and admin
- provide placeholder templates for login, signup, dataset catalog/detail and other pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6c1e149c48329b0cf21bdca950692