### PR TITLE
Add My Account dashboard with tabbed settings and session management

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from routes.data import bp as data_bp
 from routes.model import bp as model_bp
 from routes.categories import bp as categories_bp
 from routes.auth import bp as auth_bp
+from routes.my_account import bp as my_account_bp
 from routes.datasets import bp as datasets_bp
 from routes.projects import bp as projects_bp
 from routes.dashboards import bp as dashboards_bp
@@ -19,10 +20,12 @@ from routes.admin import bp as admin_bp
 from services.data_ingestion import cache_series, fetch_remote_series
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", "dev")
 app.register_blueprint(data_bp)
 app.register_blueprint(model_bp)
 app.register_blueprint(categories_bp)
 app.register_blueprint(auth_bp)
+app.register_blueprint(my_account_bp)
 app.register_blueprint(datasets_bp)
 app.register_blueprint(projects_bp)
 app.register_blueprint(dashboards_bp)

--- a/routes/my_account.py
+++ b/routes/my_account.py
@@ -1,0 +1,112 @@
+"""My Account dashboard and settings routes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import requests
+from flask import (
+    Blueprint,
+    render_template,
+    session,
+    redirect,
+    url_for,
+    request,
+)
+
+from .auth import registered_users, active_sessions
+
+bp = Blueprint("my_account", __name__, url_prefix="/my-account")
+
+
+def _current_user() -> dict | None:
+    email = session.get("user")
+    if not email:
+        return None
+    for user in registered_users:
+        if user.get("email") == email:
+            return user
+    return None
+
+
+@bp.before_request
+def require_login() -> Any:
+    if "user" not in session:
+        return redirect(url_for("auth.login"))
+    return None
+
+
+def _fetch_orcid_name(orcid_id: str) -> str | None:
+    try:
+        resp = requests.get(
+            f"https://pub.orcid.org/v3.0/{orcid_id}",
+            headers={"Accept": "application/json"},
+            timeout=5,
+        )
+        if resp.ok:
+            data = resp.json()
+            name = data.get("person", {}).get("name", {})
+            given = name.get("given-names", {}).get("value", "")
+            family = name.get("family-name", {}).get("value", "")
+            return f"{given} {family}".strip() or None
+    except Exception:
+        pass
+    return None
+
+
+@bp.route("/", methods=["GET", "POST"])
+@bp.route("", methods=["GET", "POST"])
+def dashboard():
+    user = _current_user()
+    if user is None:
+        return redirect(url_for("auth.login"))
+    action = request.form.get("action")
+    if request.method == "POST" and action:
+        if action == "update_profile":
+            user["name"] = request.form.get("name", user.get("name"))
+            user["affiliation"] = request.form.get(
+                "affiliation", user.get("affiliation", "")
+            )
+            orcid = request.form.get("orcid", "").strip() or None
+            user["orcid"] = orcid
+        elif action == "change_password":
+            new_pwd = request.form.get("password")
+            if new_pwd:
+                user["password"] = new_pwd
+        elif action == "update_preferences":
+            prefs = user.setdefault("preferences", {})
+            prefs["language"] = request.form.get("language", prefs.get("language"))
+            prefs["timezone"] = request.form.get("timezone", prefs.get("timezone"))
+            prefs["theme"] = request.form.get("theme", prefs.get("theme"))
+            notes = user.setdefault("notifications", {})
+            notes["email"] = bool(request.form.get("notify_email"))
+            notes["in_app"] = bool(request.form.get("notify_in_app"))
+        elif action == "request_backup":
+            user.setdefault("backups", []).append(
+                {
+                    "requested_at": datetime.utcnow(),
+                    "status": "Processing",
+                }
+            )
+    sessions = active_sessions.get(user["email"], [])
+    orcid_name = _fetch_orcid_name(user.get("orcid")) if user.get("orcid") else None
+    return render_template(
+        "my_account/index.html",
+        user=user,
+        sessions=sessions,
+        orcid_name=orcid_name,
+    )
+
+
+@bp.post("/session/<token>/revoke")
+def revoke_session(token: str):
+    user = _current_user()
+    if user is None:
+        return redirect(url_for("auth.login"))
+    user_sessions = active_sessions.get(user["email"], [])
+    active_sessions[user["email"]] = [s for s in user_sessions if s["token"] != token]
+    if session.get("session_token") == token:
+        session.clear()
+        return redirect(url_for("auth.login"))
+    return redirect(url_for("my_account.dashboard"))

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,11 +2,27 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
     {% block head %}{% endblock %}
   </head>
-  <body>
-    {% block content %}{% endblock %}
+  <body class="flex min-h-screen flex-col">
+    <header class="bg-gray-800 text-white">
+      <nav class="container mx-auto flex items-center justify-between p-4">
+        <a href="/" class="text-lg font-bold">Economical</a>
+        <div class="space-x-4">
+          {% if session.get('user') %}
+          <a href="{{ url_for('my_account.dashboard') }}" class="hover:underline">My Account</a>
+          {% else %}
+          <a href="{{ url_for('auth.login') }}" class="hover:underline">Login</a>
+          <a href="{{ url_for('auth.signup') }}" class="hover:underline">Sign Up</a>
+          {% endif %}
+        </div>
+      </nav>
+    </header>
+    <main class="container mx-auto flex-1 p-4">
+      {% block content %}{% endblock %}
+    </main>
     <script src="{{ url_for('static', filename='js/filter.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tooltips.js') }}"></script>
     {% block scripts %}{% endblock %}

--- a/templates/my_account/index.html
+++ b/templates/my_account/index.html
@@ -1,0 +1,198 @@
+{% extends 'base.html' %}
+{% block head %}
+<script src="https://cdn.tailwindcss.com"></script>
+{% endblock %}
+{% block content %}
+<div class="mx-auto max-w-4xl">
+  <h1 class="mb-4 text-2xl font-bold">My Account</h1>
+  <div>
+    <nav class="flex border-b" id="tabs">
+      <button data-tab-button data-tab-target="tab-profile" class="px-4 py-2 text-sm">Profile</button>
+      <button data-tab-button data-tab-target="tab-security" class="px-4 py-2 text-sm">Security</button>
+      <button data-tab-button data-tab-target="tab-preferences" class="px-4 py-2 text-sm">Preferences</button>
+      <button data-tab-button data-tab-target="tab-exports" class="px-4 py-2 text-sm">Exports &amp; Backups</button>
+      <button data-tab-button data-tab-target="tab-publications" class="px-4 py-2 text-sm">Publication History</button>
+    </nav>
+    <div class="mt-4">
+      <div id="tab-profile" data-tab class="space-y-2">
+        <p><strong>Name:</strong> {{ user.name }}</p>
+        <p><strong>Email:</strong> {{ user.email }}</p>
+        <p><strong>Affiliation:</strong> {{ user.affiliation }}</p>
+        <p><strong>ORCID:</strong> {{ user.orcid or 'Not linked' }}{% if orcid_name %} ({{ orcid_name }}){% endif %}</p>
+        <button class="mt-2 rounded bg-indigo-600 px-4 py-2 text-white" onclick="toggleModal('profileModal', true)">Edit Profile</button>
+      </div>
+      <div id="tab-security" data-tab class="hidden">
+        <form method="post" class="space-y-4">
+          <input type="hidden" name="action" value="change_password" />
+          <div>
+            <label class="block text-sm font-medium">New Password</label>
+            <input name="password" type="password" class="mt-1 w-full rounded border p-2" />
+          </div>
+          <button class="rounded bg-indigo-600 px-4 py-2 text-white">Change Password</button>
+        </form>
+        <h3 class="mt-6 text-lg font-semibold">Active Sessions</h3>
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr>
+              <th class="px-4 py-2 text-left text-sm font-medium">IP</th>
+              <th class="px-4 py-2 text-left text-sm font-medium">Login At</th>
+              <th class="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for s in sessions %}
+            <tr class="border-b">
+              <td class="px-4 py-2 text-sm">{{ s.ip }}</td>
+              <td class="px-4 py-2 text-sm">{{ s.login_at }}</td>
+              <td class="px-4 py-2 text-right">
+                <form method="post" action="{{ url_for('my_account.revoke_session', token=s.token) }}">
+                  <button class="text-red-600 hover:underline">Revoke</button>
+                </form>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="3" class="px-4 py-2 text-center text-sm text-gray-500">No active sessions</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div id="tab-preferences" data-tab class="hidden">
+        <form method="post" class="space-y-4">
+          <input type="hidden" name="action" value="update_preferences" />
+          <div>
+            <label class="block text-sm font-medium">Language</label>
+            <select name="language" class="mt-1 w-full rounded border p-2">
+              <option value="en" {% if user.preferences.language=='en' %}selected{% endif %}>English</option>
+              <option value="ko" {% if user.preferences.language=='ko' %}selected{% endif %}>Korean</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium">Timezone</label>
+            <input name="timezone" value="{{ user.preferences.timezone }}" class="mt-1 w-full rounded border p-2" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium">Theme</label>
+            <select name="theme" class="mt-1 w-full rounded border p-2">
+              <option value="light" {% if user.preferences.theme=='light' %}selected{% endif %}>Light</option>
+              <option value="dark" {% if user.preferences.theme=='dark' %}selected{% endif %}>Dark</option>
+              <option value="auto" {% if user.preferences.theme=='auto' %}selected{% endif %}>Auto</option>
+            </select>
+          </div>
+          <div class="space-y-2">
+            <label class="flex items-center"><input type="checkbox" name="notify_email" class="mr-2" {% if user.notifications.email %}checked{% endif %}/> Email alerts</label>
+            <label class="flex items-center"><input type="checkbox" name="notify_in_app" class="mr-2" {% if user.notifications.in_app %}checked{% endif %}/> In-app notifications</label>
+          </div>
+          <button class="rounded bg-indigo-600 px-4 py-2 text-white">Save Preferences</button>
+        </form>
+      </div>
+      <div id="tab-exports" data-tab class="hidden">
+        <h3 class="mb-2 text-lg font-semibold">Export History</h3>
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr>
+              <th class="px-4 py-2 text-left text-sm font-medium">ID</th>
+              <th class="px-4 py-2 text-left text-sm font-medium">Name</th>
+              <th class="px-4 py-2 text-left text-sm font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for e in user.exports %}
+            <tr class="border-b"><td class="px-4 py-2 text-sm">{{ e.id }}</td><td class="px-4 py-2 text-sm">{{ e.name }}</td><td class="px-4 py-2 text-sm">{{ e.status }}</td></tr>
+            {% else %}
+            <tr><td colspan="3" class="px-4 py-2 text-center text-sm text-gray-500">No exports</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <h3 class="mt-6 mb-2 text-lg font-semibold">Backups</h3>
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead><tr><th class="px-4 py-2 text-left text-sm font-medium">Requested At</th><th class="px-4 py-2 text-left text-sm font-medium">Status</th></tr></thead>
+          <tbody>
+            {% for b in user.backups %}
+            <tr class="border-b"><td class="px-4 py-2 text-sm">{{ b.requested_at }}</td><td class="px-4 py-2 text-sm">{{ b.status }}</td></tr>
+            {% else %}
+            <tr><td colspan="2" class="px-4 py-2 text-center text-sm text-gray-500">No backups</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <button class="mt-4 rounded bg-indigo-600 px-4 py-2 text-white" onclick="toggleModal('backupModal', true)">Request Backup</button>
+      </div>
+      <div id="tab-publications" data-tab class="hidden">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead><tr><th class="px-4 py-2 text-left text-sm font-medium">DOI</th><th class="px-4 py-2 text-left text-sm font-medium">Title</th><th class="px-4 py-2 text-left text-sm font-medium">Status</th></tr></thead>
+          <tbody>
+            {% for p in user.publications %}
+            <tr class="border-b"><td class="px-4 py-2 text-sm">{{ p.doi }}</td><td class="px-4 py-2 text-sm">{{ p.title }}</td><td class="px-4 py-2 text-sm">{{ p.status }}</td></tr>
+            {% else %}
+            <tr><td colspan="3" class="px-4 py-2 text-center text-sm text-gray-500">No publications</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Profile Modal -->
+<div id="profileModal" class="fixed inset-0 z-10 hidden items-center justify-center bg-black bg-opacity-50">
+  <div class="w-full max-w-md rounded bg-white p-6">
+    <h2 class="mb-4 text-xl font-semibold">Edit Profile</h2>
+    <form method="post" class="space-y-4">
+      <input type="hidden" name="action" value="update_profile" />
+      <div>
+        <label class="block text-sm font-medium">Name</label>
+        <input name="name" value="{{ user.name }}" class="mt-1 w-full rounded border p-2" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium">Affiliation</label>
+        <input name="affiliation" value="{{ user.affiliation }}" class="mt-1 w-full rounded border p-2" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium">ORCID iD</label>
+        <input name="orcid" value="{{ user.orcid or '' }}" class="mt-1 w-full rounded border p-2" />
+      </div>
+      <div class="flex justify-end">
+        <button type="button" class="mr-2 px-4 py-2" onclick="toggleModal('profileModal', false)">Cancel</button>
+        <button class="rounded bg-indigo-600 px-4 py-2 text-white">Save</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Backup Confirmation Modal -->
+<div id="backupModal" class="fixed inset-0 z-10 hidden items-center justify-center bg-black bg-opacity-50">
+  <div class="w-full max-w-sm rounded bg-white p-6">
+    <h2 class="mb-4 text-xl font-semibold">Confirm Backup</h2>
+    <form method="post" class="space-y-4">
+      <input type="hidden" name="action" value="request_backup" />
+      <p>Start a new personal backup?</p>
+      <div class="flex justify-end">
+        <button type="button" class="mr-2 px-4 py-2" onclick="toggleModal('backupModal', false)">Cancel</button>
+        <button class="rounded bg-indigo-600 px-4 py-2 text-white">Start</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function showTab(id) {
+  document.querySelectorAll('[data-tab]').forEach(el => el.classList.add('hidden'));
+  document.getElementById(id).classList.remove('hidden');
+  document.querySelectorAll('[data-tab-button]').forEach(btn => btn.classList.remove('border-b-2','border-indigo-600','text-indigo-600'));
+  document.querySelector(`[data-tab-button][data-tab-target="${id}"]`).classList.add('border-b-2','border-indigo-600','text-indigo-600');
+}
+function toggleModal(id, show){
+  const el = document.getElementById(id);
+  if(show){ el.classList.remove('hidden'); el.classList.add('flex'); }
+  else { el.classList.add('hidden'); el.classList.remove('flex'); }
+}
+
+document.querySelectorAll('[data-tab-button]').forEach(btn => {
+  btn.addEventListener('click', () => showTab(btn.getAttribute('data-tab-target')));
+});
+showTab('tab-profile');
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Introduce My Account blueprint with Tailwind tabbed interface for profile, security, preferences, exports/backups, and publication history.
- Implement basic session handling, ORCID lookups, and preference management; include modals for profile editing and backup confirmation.
- Add global header with conditional My Account link and enable session support in the app.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6cb6714d48329925d9474b9573931