### PR TITLE
feat: enhance notifications list with realtime tabs

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -1,0 +1,85 @@
+// Notifications page client-side logic
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tabs = document.querySelectorAll('#notification-tabs .tab-link');
+  const lists = document.querySelectorAll('.notification-list');
+  const loading = document.getElementById('loading');
+  const empty = document.getElementById('empty');
+  const error = document.getElementById('error');
+  const markAllBtn = document.getElementById('mark-all-read');
+
+  function showTab(id) {
+    lists.forEach(list => list.classList.add('hidden'));
+    const active = document.getElementById(id);
+    if (active) active.classList.remove('hidden');
+    tabs.forEach(t => t.classList.remove('border-blue-500', 'text-blue-600'));
+    const current = document.querySelector(`.tab-link[data-tab="${id}"]`);
+    if (current) current.classList.add('border-blue-500', 'text-blue-600');
+  }
+
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => showTab(tab.dataset.tab));
+  });
+  showTab('realtime');
+
+  function updateEmpty() {
+    const total = Array.from(lists).reduce((sum, l) => sum + l.children.length, 0);
+    if (total === 0) {
+      empty.classList.remove('hidden');
+    } else {
+      empty.classList.add('hidden');
+    }
+  }
+
+  if (markAllBtn) {
+    markAllBtn.addEventListener('click', () => {
+      document.querySelectorAll('.notification-list li.unread').forEach(li => {
+        li.classList.remove('bg-blue-50', 'font-semibold', 'unread');
+        li.classList.add('text-gray-500');
+        const indicator = li.querySelector('.unread-indicator');
+        if (indicator) indicator.remove();
+        li.dataset.read = 'true';
+      });
+    });
+  }
+
+  let opened = false;
+  const wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws/notifications';
+  try {
+    const ws = new WebSocket(wsUrl);
+    ws.addEventListener('open', () => {
+      opened = true;
+      loading.classList.add('hidden');
+      updateEmpty();
+    });
+    ws.addEventListener('message', e => {
+      const data = JSON.parse(e.data);
+      const channel = data.channel || 'realtime';
+      const list = document.getElementById(channel);
+      if (!list) return;
+      const li = document.createElement('li');
+      li.className = 'flex justify-between items-center p-4 hover:bg-gray-50 bg-blue-50 font-semibold unread';
+      li.dataset.read = 'false';
+      li.innerHTML = `<span>${data.message}</span><span class="unread-indicator ml-4 h-2 w-2 rounded-full bg-blue-500"></span>`;
+      list.prepend(li);
+      updateEmpty();
+    });
+    ws.addEventListener('close', () => {
+      if (!opened) {
+        loading.classList.add('hidden');
+        error.classList.remove('hidden');
+      }
+    });
+    ws.addEventListener('error', () => {
+      loading.classList.add('hidden');
+      error.classList.remove('hidden');
+    });
+  } catch (err) {
+    loading.classList.add('hidden');
+    error.classList.remove('hidden');
+  }
+
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/static/js/sw.js').catch(() => {});
+  }
+});

--- a/static/js/sw.js
+++ b/static/js/sw.js
@@ -1,0 +1,12 @@
+self.addEventListener('push', event => {
+  const data = event.data?.json() || {};
+  event.waitUntil(
+    self.registration.showNotification(data.title || 'Economical', {
+      body: data.message || '',
+    })
+  );
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+});

--- a/templates/notifications/list.html
+++ b/templates/notifications/list.html
@@ -1,5 +1,36 @@
 {% extends 'base.html' %}
+
 {% block content %}
-<h1>Notifications</h1>
-<p>User notifications will appear here.</p>
+<div class="mb-6">
+  <div class="flex items-center justify-between mb-4">
+    <h1 class="text-2xl font-bold">Notifications</h1>
+    <div class="space-x-4 text-sm">
+      <button id="mark-all-read" class="text-blue-600 hover:underline">Mark All as Read</button>
+      <a href="{{ url_for('my_account.dashboard') }}#notification-settings" class="text-blue-600 hover:underline">Notification Settings</a>
+    </div>
+  </div>
+
+  <div class="border-b border-gray-200 mb-4">
+    <nav id="notification-tabs" class="flex space-x-4">
+      <button class="tab-link px-3 py-2 text-sm font-medium text-gray-600 border-b-2 border-transparent" data-tab="realtime">Real-time Alerts</button>
+      <button class="tab-link px-3 py-2 text-sm font-medium text-gray-600 border-b-2 border-transparent" data-tab="subscriptions">Subscriptions</button>
+      <button class="tab-link px-3 py-2 text-sm font-medium text-gray-600 border-b-2 border-transparent" data-tab="system">System Messages</button>
+    </nav>
+  </div>
+
+  <div id="tab-content">
+    <ul id="realtime" class="notification-list hidden divide-y divide-gray-200"></ul>
+    <ul id="subscriptions" class="notification-list hidden divide-y divide-gray-200"></ul>
+    <ul id="system" class="notification-list hidden divide-y divide-gray-200"></ul>
+    <div id="loading" class="py-8 text-center text-gray-500">Fetching notifications…</div>
+    <div id="empty" class="hidden py-8 text-center text-gray-500">You have no notifications.</div>
+    <div id="error" class="hidden py-8 text-center text-red-500">Failed to load notifications.</div>
+  </div>
+</div>
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add tabbed layout with global actions for notifications
- display notification lists with Tailwind styles and read/unread indicators
- connect WebSocket and push service with empty/loading/error handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6ce8f1f088329ad3ba667f6c62737