### PR TITLE
Automate ERD schema migrations and add API docs

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -37,8 +37,10 @@ def register_user_with_database(conn: pymysql.connections.Connection, user_id: i
     db_user = username
     db_password = secrets.token_urlsafe(16)
 
-    migrations_dir = Path(__file__).resolve().parent.parent / "migrations"
-    apply_migrations(conn, migrations_dir)
+    root_dir = Path(__file__).resolve().parent.parent
+    migrations_dir = root_dir / "migrations"
+    erd_path = root_dir / "docs" / "ERD.md"
+    apply_migrations(conn, migrations_dir, erd_path)
 
     with conn.cursor() as cur:
         # Create database and user

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,92 @@
+# API Reference
+
+This document lists the current HTTP endpoints for the Economical backend. The
+endpoints are grouped by feature area and reference the related specification
+documents in `docs/specification`.
+
+## Root
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | Service status check |
+
+## Authentication
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET, POST | `/auth/login` | User login | [login](specification/login.md) |
+| GET, POST | `/auth/signup` | Create a new account | [signup](specification/signup.md) |
+| GET | `/auth/check-email` | Check if an email is already registered | [signup](specification/signup.md) |
+| GET, POST | `/auth/password-reset` | Request password reset email | [password_reset](specification/password_reset.md) |
+| GET, POST | `/auth/password-reset/<token>` | Reset password using token | [password_reset](specification/password_reset.md) |
+| GET | `/auth/password-reset/success` | Password reset success page | [password_reset](specification/password_reset.md) |
+
+## Data API
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET | `/api/data/<series_id>` | Retrieve cached time series data | [dataset_detail_api](specification/dataset_detail_api.md) |
+| GET | `https://api.economical.click/v1/datasets/{dataset_id}/records` | Fetch dataset records | [dataset_detail_api](specification/dataset_detail_api.md) |
+| GET | `https://api.economical.click/v1/datasets/{dataset_id}/schema` | Fetch dataset schema | [dataset_detail_api](specification/dataset_detail_api.md) |
+| GET | `https://api.economical.click/v1/datasets/{dataset_id}/metadata` | Fetch dataset metadata | [dataset_detail_api](specification/dataset_detail_api.md) |
+
+## Datasets
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET | `/datasets/` | List available datasets | [dataset_catalog](specification/dataset_catalog.md) |
+| GET | `/datasets/<dataset_id>` | Show dataset details | [dataset_detail_overview](specification/dataset_detail_overview.md) |
+
+## Projects
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET | `/projects/` | List projects | [project_catalog](specification/project_catalog.md) |
+| GET | `/projects/<project_id>` | Project detail view | [project_detail](specification/project_detail.md) |
+
+## Dashboards
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET | `/dashboards/` | Dashboard catalog | [dashboard_catalog](specification/dashboard_catalog.md) |
+| GET | `/dashboards/<dashboard_id>` | Dashboard detail | [dashboard_detail](specification/dashboard_detail.md) |
+
+## Community
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET | `/community/` | Community landing page | [community](specification/community.md) |
+
+## Categories
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/categories/` | Root categories listing |
+| GET | `/categories/<path:subpath>` | Nested category listing |
+
+## Model Builder
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET | `/model/` | Display model building form | [model_builder](specification/model_builder.md) |
+| POST | `/model/` | Run model fitting pipeline | [model_builder](specification/model_builder.md) |
+
+## My Account
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET, POST | `/my-account` | Personal dashboard and updates | [my_account](specification/my_account.md) |
+| GET, POST | `/my-account/` | Personal dashboard (trailing slash) | [my_account](specification/my_account.md) |
+| POST | `/my-account/session/<token>/revoke` | Revoke active session | [my_account](specification/my_account.md) |
+
+## Notifications
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET | `/notifications/` | Notification center | [notifications](specification/notifications.md) |
+
+## Admin
+
+| Method | Path | Description | Spec |
+|--------|------|-------------|------|
+| GET | `/admin/` | Admin dashboard | [admin](specification/admin.md) |

--- a/services/erd.py
+++ b/services/erd.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import pymysql
+
+# Map ERD types to MySQL column types
+TYPE_MAP = {
+    "uuid": "CHAR(36)",
+    "string": "VARCHAR(255)",
+    "int": "INT",
+    "datetime": "DATETIME",
+    "json": "JSON",
+}
+
+
+def parse_erd(erd_path: Path) -> dict[str, list[tuple[str, str]]]:
+    """Parse a Mermaid ERD file into table definitions.
+
+    Parameters
+    ----------
+    erd_path:
+        Path to the ERD markdown file containing a ``mermaid`` ``erDiagram``.
+
+    Returns
+    -------
+    dict
+        Mapping of table name to list of ``(column_name, sql_type)`` tuples.
+    """
+    tables: dict[str, list[tuple[str, str]]] = {}
+    current_table: str | None = None
+    for line in erd_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("%%"):
+            continue
+        match = re.match(r"([A-Z_]+) \{", line)
+        if match:
+            current_table = match.group(1).lower()
+            tables[current_table] = []
+            continue
+        if line == "}" and current_table:
+            current_table = None
+            continue
+        if current_table:
+            parts = line.split()
+            if len(parts) >= 2:
+                col_type, col_name = parts[0], parts[1]
+                sql_type = TYPE_MAP.get(col_type.lower(), "TEXT")
+                tables[current_table].append((col_name, sql_type))
+    return tables
+
+
+def apply_erd_schema(conn: pymysql.connections.Connection, erd_path: Path) -> None:
+    """Create tables defined in the ERD if they do not exist."""
+    tables = parse_erd(erd_path)
+    with conn.cursor() as cur:
+        for table, columns in tables.items():
+            col_defs = ",\n".join(f"    {name} {ctype}" for name, ctype in columns)
+            sql = f"CREATE TABLE IF NOT EXISTS {table} (\n{col_defs}\n);"
+            cur.execute(sql)
+    conn.commit()


### PR DESCRIPTION
## Summary
- Parse Mermaid ERD and apply tables automatically during migrations
- Integrate ERD-driven schema creation into user registration workflow
- Document available API endpoints under `docs/api.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6d3bb02c4832999d0c36b387ccfc6