### PR TITLE
Add SocketIO websocket support

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from routes.community import bp as community_bp
 from routes.notifications import bp as notifications_bp
 from routes.admin import bp as admin_bp
 from services.data_ingestion import cache_series, fetch_remote_series
+from ws import init_app as init_ws, socketio
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
@@ -32,6 +33,8 @@ app.register_blueprint(dashboards_bp)
 app.register_blueprint(community_bp)
 app.register_blueprint(notifications_bp)
 app.register_blueprint(admin_bp)
+
+init_ws(app)
 
 load_dotenv()
 
@@ -58,4 +61,4 @@ def index() -> str:
 
 
 if __name__ == "__main__":
-    app.run()
+    socketio.run(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scikit-learn
 yfinance
 statsmodels
 matplotlib
+Flask-SocketIO

--- a/routes/datasets.py
+++ b/routes/datasets.py
@@ -1,6 +1,7 @@
 """Dataset catalog and detail views."""
 
 from flask import Blueprint, render_template
+from ws import emit_dataset_update
 
 bp = Blueprint("datasets", __name__, url_prefix="/datasets")
 
@@ -14,4 +15,5 @@ def catalog():
 @bp.get("/<int:dataset_id>")
 def detail(dataset_id: int):
     """Show dataset details."""
+    emit_dataset_update(dataset_id, {"message": f"dataset {dataset_id} viewed"})
     return render_template("datasets/detail.html", dataset_id=dataset_id)

--- a/routes/model.py
+++ b/routes/model.py
@@ -4,6 +4,7 @@ import base64
 import io
 
 from flask import Blueprint, render_template, request, url_for
+from ws import emit_model_update
 
 import matplotlib.pyplot as plt
 
@@ -67,7 +68,8 @@ def run_model() -> str:
         if not features.empty
         else {}
     )
-
+    
+    emit_model_update(model_type, {"message": f"model run for {symbol}"})
     return render_template(
         "model_result.html",
         symbol=symbol,

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -1,6 +1,7 @@
 """User notification routes."""
 
 from flask import Blueprint, render_template
+from ws import emit_notification
 
 bp = Blueprint("notifications", __name__, url_prefix="/notifications")
 
@@ -8,4 +9,5 @@ bp = Blueprint("notifications", __name__, url_prefix="/notifications")
 @bp.get("/")
 def list_notifications():
     """List notifications for the current user."""
+    emit_notification("notification list accessed")
     return render_template("notifications/list.html")

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -1,6 +1,7 @@
 """Project catalog and detail views."""
 
 from flask import Blueprint, render_template
+from ws import emit_project_update
 
 bp = Blueprint("projects", __name__, url_prefix="/projects")
 
@@ -14,4 +15,5 @@ def catalog():
 @bp.get("/<int:project_id>")
 def detail(project_id: int):
     """Show project details."""
+    emit_project_update(project_id, {"message": f"project {project_id} viewed"})
     return render_template("projects/detail.html", project_id=project_id)

--- a/ws/__init__.py
+++ b/ws/__init__.py
@@ -1,0 +1,79 @@
+"""WebSocket handlers using Flask-SocketIO."""
+from __future__ import annotations
+
+from flask import request
+from flask_socketio import SocketIO, emit, join_room
+
+socketio = SocketIO()
+
+
+def init_app(app):
+    """Initialize SocketIO with the given Flask app."""
+    socketio.init_app(app, cors_allowed_origins="*")
+
+
+@socketio.on("connect", namespace="/ws/notifications")
+def notifications_connect():
+    """Notify clients they are connected to notifications channel."""
+    emit("notification", {"message": "connected"})
+
+
+@socketio.on("connect", namespace="/ws/datasets")
+def datasets_connect():
+    """Join a room for a specific dataset."""
+    dataset_id = request.args.get("dataset_id")
+    if dataset_id:
+        join_room(dataset_id)
+        emit("dataset_update", {"message": f"joined dataset {dataset_id}"})
+    else:
+        emit("error", {"message": "dataset_id required"})
+
+
+@socketio.on("connect", namespace="/ws/models")
+def models_connect():
+    """Join a room for a specific model."""
+    model_id = request.args.get("model_id")
+    if model_id:
+        join_room(model_id)
+        emit("model_update", {"message": f"joined model {model_id}"})
+    else:
+        emit("error", {"message": "model_id required"})
+
+
+@socketio.on("connect", namespace="/ws/projects")
+def projects_connect():
+    """Join a room for a specific project."""
+    project_id = request.args.get("project_id")
+    if project_id:
+        join_room(project_id)
+        emit("project_update", {"message": f"joined project {project_id}"})
+    else:
+        emit("error", {"message": "project_id required"})
+
+
+# Server-side emit helpers -------------------------------------------------
+
+def emit_notification(message: str) -> None:
+    """Emit a notification event to all subscribers."""
+    socketio.emit("notification", {"message": message}, namespace="/ws/notifications")
+
+
+def emit_dataset_update(dataset_id: int, payload: dict) -> None:
+    """Emit an update for a dataset room."""
+    socketio.emit(
+        "dataset_update", payload, namespace="/ws/datasets", room=str(dataset_id)
+    )
+
+
+def emit_model_update(model_id: int | str, payload: dict) -> None:
+    """Emit an update for a model room."""
+    socketio.emit(
+        "model_update", payload, namespace="/ws/models", room=str(model_id)
+    )
+
+
+def emit_project_update(project_id: int, payload: dict) -> None:
+    """Emit an update for a project room."""
+    socketio.emit(
+        "project_update", payload, namespace="/ws/projects", room=str(project_id)
+    )


### PR DESCRIPTION
## Summary
- add Flask-SocketIO dependency
- configure SocketIO and websocket handlers for notifications, datasets, models, and projects
- emit sample events from existing routes so clients can receive updates

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a714b064d883298f9060f4fc762d86