### PR TITLE
feat: add notification websocket channel

### DIFF
--- a/scripts/push_notification.py
+++ b/scripts/push_notification.py
@@ -1,0 +1,20 @@
+"""Utility script to simulate server push during development."""
+
+from __future__ import annotations
+
+import sys
+
+from app import app
+from services.notifications import create_notification
+
+
+def main() -> None:
+    user = sys.argv[1] if len(sys.argv) > 1 else "test@example.com"
+    message = " ".join(sys.argv[2:]) if len(sys.argv) > 2 else "Hello from dev script"
+    with app.app_context():
+        create_notification(user, message, "info")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/services/notifications.py
+++ b/services/notifications.py
@@ -1,0 +1,35 @@
+"""In-memory notification service with WebSocket push support."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from itertools import count
+from typing import Dict, Tuple
+
+from models import Notification
+from ws import emit_user_notification
+
+# Simple in-memory store for notifications {id: (user_email, Notification)}
+_notifications: Dict[int, Tuple[str, Notification]] = {}
+_ids = count(1)
+
+
+def create_notification(user: str, message: str, type: str) -> Notification:
+    """Create a notification for ``user`` and push it to active sessions."""
+    notification = Notification(id=next(_ids), message=message, type=type)
+    _notifications[notification.id] = (user, notification)
+    payload = asdict(notification)
+    payload["created_at"] = notification.created_at.isoformat()
+    emit_user_notification(user, payload)
+    return notification
+
+
+def update_notification(notification_id: int, **changes) -> Notification:
+    """Update an existing notification and push changes to the user."""
+    user, notification = _notifications[notification_id]
+    for key, value in changes.items():
+        setattr(notification, key, value)
+    payload = asdict(notification)
+    payload["created_at"] = notification.created_at.isoformat()
+    emit_user_notification(user, payload)
+    return notification
+

--- a/ws/__init__.py
+++ b/ws/__init__.py
@@ -1,10 +1,17 @@
 """WebSocket handlers using Flask-SocketIO."""
 from __future__ import annotations
 
-from flask import request
+from collections import defaultdict
+from flask import request, session
 from flask_socketio import SocketIO, emit, join_room
 
 socketio = SocketIO()
+
+# Track active notification connections per user session
+# Structure: {user_email: {session_token: {sid, ...}}}
+notification_connections: dict[str, dict[str, set[str]]] = defaultdict(
+    lambda: defaultdict(set)
+)
 
 
 def init_app(app):
@@ -14,8 +21,29 @@ def init_app(app):
 
 @socketio.on("connect", namespace="/ws/notifications")
 def notifications_connect():
-    """Notify clients they are connected to notifications channel."""
+    """Register a client connection for notifications."""
+    user = session.get("user")
+    token = session.get("session_token")
+    if user and token:
+        notification_connections[user][token].add(request.sid)
     emit("notification", {"message": "connected"})
+
+
+@socketio.on("disconnect", namespace="/ws/notifications")
+def notifications_disconnect():
+    """Remove a client connection when it disconnects."""
+    user = session.get("user")
+    token = session.get("session_token")
+    if not (user and token):
+        return
+    sessions = notification_connections.get(user, {})
+    sids = sessions.get(token)
+    if sids and request.sid in sids:
+        sids.remove(request.sid)
+        if not sids:
+            del sessions[token]
+    if not sessions:
+        notification_connections.pop(user, None)
 
 
 @socketio.on("connect", namespace="/ws/datasets")
@@ -54,8 +82,15 @@ def projects_connect():
 # Server-side emit helpers -------------------------------------------------
 
 def emit_notification(message: str) -> None:
-    """Emit a notification event to all subscribers."""
+    """Broadcast a simple notification to all subscribers."""
     socketio.emit("notification", {"message": message}, namespace="/ws/notifications")
+
+
+def emit_user_notification(user: str, payload: dict) -> None:
+    """Emit a notification payload to all active sessions of a user."""
+    for sids in notification_connections.get(user, {}).values():
+        for sid in sids:
+            socketio.emit("notification", payload, namespace="/ws/notifications", to=sid)
 
 
 def emit_dataset_update(dataset_id: int, payload: dict) -> None:


### PR DESCRIPTION
## Summary
- add per-user websocket handling for /ws/notifications
- push notifications when records are created or updated
- include helper script to simulate server-side pushes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a71899e69083299764d97bdf6f2289