### PR TITLE
Add dataset API and live catalog updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,9 @@ from routes.dashboards import bp as dashboards_bp
 from routes.community import bp as community_bp
 from routes.notifications import bp as notifications_bp
 from routes.admin import bp as admin_bp
+from routes.api_datasets import bp as api_datasets_bp
+from routes.api_projects import bp as api_projects_bp
+from routes.api_dashboards import bp as api_dashboards_bp
 from services.data_ingestion import cache_series, fetch_remote_series
 from ws import init_app as init_ws, socketio
 from models.db import Base, engine
@@ -37,6 +40,9 @@ app.register_blueprint(dashboards_bp)
 app.register_blueprint(community_bp)
 app.register_blueprint(notifications_bp)
 app.register_blueprint(admin_bp)
+app.register_blueprint(api_datasets_bp)
+app.register_blueprint(api_projects_bp)
+app.register_blueprint(api_dashboards_bp)
 
 init_ws(app)
 

--- a/routes/api_dashboards.py
+++ b/routes/api_dashboards.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, jsonify
+
+bp = Blueprint("api_dashboards", __name__, url_prefix="/api/dashboards")
+
+DASHBOARDS = [
+    {"id": 1, "name": "Dashboard 1", "description": "First dashboard"},
+    {"id": 2, "name": "Dashboard 2", "description": "Second dashboard"},
+]
+
+
+@bp.get("/")
+def list_dashboards():
+    """Return all dashboards."""
+    return jsonify(DASHBOARDS)
+
+
+@bp.get("/<int:dashboard_id>")
+def dashboard_detail(dashboard_id: int):
+    """Return details for a single dashboard."""
+    dashboard = next((d for d in DASHBOARDS if d["id"] == dashboard_id), None)
+    if dashboard is None:
+        return jsonify({"error": "Dashboard not found"}), 404
+    return jsonify(dashboard)

--- a/routes/api_datasets.py
+++ b/routes/api_datasets.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, jsonify
+
+bp = Blueprint("api_datasets", __name__, url_prefix="/api/datasets")
+
+DATASETS = [
+    {"id": 1, "name": "Dataset 1", "description": "First dataset"},
+    {"id": 2, "name": "Dataset 2", "description": "Second dataset"},
+]
+
+
+@bp.get("/")
+def list_datasets():
+    """Return all datasets."""
+    return jsonify(DATASETS)
+
+
+@bp.get("/<int:dataset_id>")
+def dataset_detail(dataset_id: int):
+    """Return details for a single dataset."""
+    dataset = next((d for d in DATASETS if d["id"] == dataset_id), None)
+    if dataset is None:
+        return jsonify({"error": "Dataset not found"}), 404
+    return jsonify(dataset)

--- a/routes/api_projects.py
+++ b/routes/api_projects.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, jsonify
+
+bp = Blueprint("api_projects", __name__, url_prefix="/api/projects")
+
+PROJECTS = [
+    {"id": 1, "name": "Project 1", "description": "First project"},
+    {"id": 2, "name": "Project 2", "description": "Second project"},
+]
+
+
+@bp.get("/")
+def list_projects():
+    """Return all projects."""
+    return jsonify(PROJECTS)
+
+
+@bp.get("/<int:project_id>")
+def project_detail(project_id: int):
+    """Return details for a single project."""
+    project = next((p for p in PROJECTS if p["id"] == project_id), None)
+    if project is None:
+        return jsonify({"error": "Project not found"}), 404
+    return jsonify(project)

--- a/static/js/dashboards.js
+++ b/static/js/dashboards.js
@@ -1,0 +1,29 @@
+// Client-side logic for dashboard catalog page
+
+document.addEventListener('DOMContentLoaded', () => {
+  const listEl = document.getElementById('dashboard-list');
+  if (!listEl) return;
+
+  fetch('/api/dashboards')
+    .then(r => r.json())
+    .then(dashboards => {
+      dashboards.forEach(d => {
+        const card = document.createElement('div');
+        card.className = 'border rounded p-4 hover:bg-gray-50';
+        card.innerHTML = `<h3 class="font-semibold">${d.name}</h3><p>${d.description}</p>`;
+        listEl.appendChild(card);
+
+        const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/dashboards?dashboard_id=${d.id}`;
+        try {
+          const ws = new WebSocket(wsUrl);
+          ws.addEventListener('message', e => {
+            const data = JSON.parse(e.data);
+            console.log('dashboard update', d.id, data);
+          });
+        } catch (err) {
+          console.error('WebSocket error', err);
+        }
+      });
+    })
+    .catch(err => console.error('Failed to load dashboards', err));
+});

--- a/static/js/datasets.js
+++ b/static/js/datasets.js
@@ -1,0 +1,57 @@
+// Client-side logic for dataset catalog and detail pages
+
+document.addEventListener('DOMContentLoaded', () => {
+  const listEl = document.getElementById('dataset-list');
+  const detailEl = document.getElementById('dataset-detail');
+
+  if (listEl) {
+    fetch('/api/datasets')
+      .then(r => r.json())
+      .then(datasets => {
+        datasets.forEach(ds => {
+          const card = document.createElement('div');
+          card.className = 'border rounded p-4 hover:bg-gray-50 cursor-pointer';
+          card.innerHTML = `<h3 class="font-semibold">${ds.name}</h3><p>${ds.description}</p>`;
+          card.addEventListener('click', () => {
+            window.location.href = `/datasets/${ds.id}`;
+          });
+          listEl.appendChild(card);
+
+          const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/datasets?dataset_id=${ds.id}`;
+          try {
+            const ws = new WebSocket(wsUrl);
+            ws.addEventListener('message', e => {
+              const data = JSON.parse(e.data);
+              console.log('dataset update', ds.id, data);
+            });
+          } catch (err) {
+            console.error('WebSocket error', err);
+          }
+        });
+      })
+      .catch(err => console.error('Failed to load datasets', err));
+  }
+
+  if (detailEl) {
+    const datasetId = detailEl.dataset.id;
+    fetch(`/api/datasets/${datasetId}`)
+      .then(r => r.json())
+      .then(ds => {
+        detailEl.innerHTML = `<h2 class="text-xl font-bold mb-2">${ds.name}</h2><p>${ds.description}</p>`;
+      });
+
+    const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/datasets?dataset_id=${datasetId}`;
+    try {
+      const ws = new WebSocket(wsUrl);
+      ws.addEventListener('message', e => {
+        const data = JSON.parse(e.data);
+        const p = document.createElement('p');
+        p.className = 'text-sm text-gray-500';
+        p.textContent = data.message;
+        detailEl.appendChild(p);
+      });
+    } catch (err) {
+      console.error('WebSocket error', err);
+    }
+  }
+});

--- a/static/js/projects.js
+++ b/static/js/projects.js
@@ -1,0 +1,29 @@
+// Client-side logic for project catalog page
+
+document.addEventListener('DOMContentLoaded', () => {
+  const listEl = document.getElementById('project-list');
+  if (!listEl) return;
+
+  fetch('/api/projects')
+    .then(r => r.json())
+    .then(projects => {
+      projects.forEach(p => {
+        const card = document.createElement('div');
+        card.className = 'border rounded p-4 hover:bg-gray-50';
+        card.innerHTML = `<h3 class="font-semibold">${p.name}</h3><p>${p.description}</p>`;
+        listEl.appendChild(card);
+
+        const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/projects?project_id=${p.id}`;
+        try {
+          const ws = new WebSocket(wsUrl);
+          ws.addEventListener('message', e => {
+            const data = JSON.parse(e.data);
+            console.log('project update', p.id, data);
+          });
+        } catch (err) {
+          console.error('WebSocket error', err);
+        }
+      });
+    })
+    .catch(err => console.error('Failed to load projects', err));
+});

--- a/templates/dashboards/catalog.html
+++ b/templates/dashboards/catalog.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Dashboard Catalog</h1>
-<p>List of dashboards will appear here.</p>
+<div id="dashboard-list" class="grid gap-4"></div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/dashboards.js') }}"></script>
 {% endblock %}

--- a/templates/datasets/catalog.html
+++ b/templates/datasets/catalog.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Dataset Catalog</h1>
-<p>List of datasets will appear here.</p>
+<div id="dataset-list" class="grid gap-4"></div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/datasets.js') }}"></script>
 {% endblock %}

--- a/templates/datasets/detail.html
+++ b/templates/datasets/detail.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Dataset {{ dataset_id }}</h1>
-<p>Dataset details will appear here.</p>
+<div id="dataset-detail" data-id="{{ dataset_id }}"></div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/datasets.js') }}"></script>
 {% endblock %}

--- a/templates/projects/catalog.html
+++ b/templates/projects/catalog.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Project Catalog</h1>
-<p>List of projects will appear here.</p>
+<div id="project-list" class="grid gap-4"></div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/projects.js') }}"></script>
 {% endblock %}

--- a/ws/__init__.py
+++ b/ws/__init__.py
@@ -79,6 +79,17 @@ def projects_connect():
         emit("error", {"message": "project_id required"})
 
 
+@socketio.on("connect", namespace="/ws/dashboards")
+def dashboards_connect():
+    """Join a room for a specific dashboard."""
+    dashboard_id = request.args.get("dashboard_id")
+    if dashboard_id:
+        join_room(dashboard_id)
+        emit("dashboard_update", {"message": f"joined dashboard {dashboard_id}"})
+    else:
+        emit("error", {"message": "dashboard_id required"})
+
+
 # Server-side emit helpers -------------------------------------------------
 
 def emit_notification(message: str) -> None:
@@ -111,4 +122,11 @@ def emit_project_update(project_id: int, payload: dict) -> None:
     """Emit an update for a project room."""
     socketio.emit(
         "project_update", payload, namespace="/ws/projects", room=str(project_id)
+    )
+
+
+def emit_dashboard_update(dashboard_id: int, payload: dict) -> None:
+    """Emit an update for a dashboard room."""
+    socketio.emit(
+        "dashboard_update", payload, namespace="/ws/dashboards", room=str(dashboard_id)
     )


### PR DESCRIPTION
## Summary
- add JSON API blueprints for datasets, projects, and dashboards
- build client-side scripts to fetch catalog data and subscribe to WebSocket updates
- include new script loaders and containers in catalog and detail templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71ccf83a88329bf6b7ece282fa520