### PR TITLE
Extract data pipeline to daemon

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime
-from apscheduler.schedulers.background import BackgroundScheduler
 from flask import Flask
 from dotenv import load_dotenv
 
@@ -20,7 +18,6 @@ from routes.admin import bp as admin_bp
 from routes.api_datasets import bp as api_datasets_bp
 from routes.api_projects import bp as api_projects_bp
 from routes.api_dashboards import bp as api_dashboards_bp
-from services.data_ingestion import cache_series, fetch_remote_series
 from ws import init_app as init_ws, socketio
 from models.db import Base, engine
 
@@ -47,22 +44,6 @@ app.register_blueprint(api_dashboards_bp)
 init_ws(app)
 
 load_dotenv()
-
-SOURCE_URL = os.environ.get("SERIES_SOURCE", "https://example.com/api")
-SYMBOL = os.environ.get("SERIES_SYMBOL", "demo")
-START_DATE = os.environ.get("SERIES_START", "2000-01-01")
-END_DATE = os.environ.get("SERIES_END", datetime.utcnow().strftime("%Y-%m-%d"))
-
-scheduler = BackgroundScheduler()
-
-
-def fetch_and_cache() -> None:
-    df = fetch_remote_series(SOURCE_URL, SYMBOL, START_DATE, END_DATE)
-    cache_series(SYMBOL, df)
-
-
-scheduler.add_job(fetch_and_cache, "cron", hour=0, minute=0)
-scheduler.start()
 
 
 @app.route("/")

--- a/docs/data_pipeline_daemon.md
+++ b/docs/data_pipeline_daemon.md
@@ -1,0 +1,36 @@
+# Data Pipeline Daemon
+
+The data pipeline now runs in a dedicated process. Start it with:
+
+```bash
+python scripts/data_pipeline_daemon.py
+```
+
+## systemd
+
+Example unit file to run the daemon via systemd:
+
+```ini
+[Unit]
+Description=Economical data pipeline
+After=network.target
+
+[Service]
+WorkingDirectory=/path/to/economical
+ExecStart=/usr/bin/python scripts/data_pipeline_daemon.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Docker Compose
+
+To run the daemon in Docker alongside the web server:
+
+```yaml
+services:
+  data-pipeline:
+    build: .
+    command: python scripts/data_pipeline_daemon.py
+```

--- a/scripts/data_pipeline_daemon.py
+++ b/scripts/data_pipeline_daemon.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from dotenv import load_dotenv
+
+from services.data_ingestion import cache_series, fetch_remote_series
+
+load_dotenv()
+
+SOURCE_URL = os.environ.get("SERIES_SOURCE", "https://example.com/api")
+SYMBOL = os.environ.get("SERIES_SYMBOL", "demo")
+START_DATE = os.environ.get("SERIES_START", "2000-01-01")
+END_DATE = os.environ.get("SERIES_END", datetime.utcnow().strftime("%Y-%m-%d"))
+
+
+def fetch_and_cache() -> None:
+    df = fetch_remote_series(SOURCE_URL, SYMBOL, START_DATE, END_DATE)
+    cache_series(SYMBOL, df)
+
+
+if __name__ == "__main__":
+    scheduler = BlockingScheduler()
+    scheduler.add_job(fetch_and_cache, "cron", hour=0, minute=0)
+    scheduler.start()


### PR DESCRIPTION
## Summary
- Move nightly data fetch into standalone `scripts/data_pipeline_daemon.py` with a blocking scheduler
- Strip scheduler logic from `app.py` so Flask only handles HTTP and WebSocket traffic
- Document daemon usage with systemd and Docker examples

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a720f0eebc83299670cda9625aee25