### PR TITLE
Integrate SQLAlchemy ORM and database migrations

### DIFF
--- a/migrations/versions/0002_create_core_tables.py
+++ b/migrations/versions/0002_create_core_tables.py
@@ -1,0 +1,71 @@
+"""create dataset model and notification tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "datasets",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("tags", sa.String(), nullable=False, server_default=""),
+        sa.Column("visibility", sa.String(length=50), nullable=False, server_default="private"),
+        sa.Column("owner_id", sa.String(length=36), nullable=False),
+        sa.Column("owner_type", sa.String(length=50)),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_table(
+        "dataset_versions",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("dataset_id", sa.String(length=36), sa.ForeignKey("datasets.id"), nullable=False),
+        sa.Column("version_tag", sa.String(length=100), nullable=False),
+        sa.Column("changelog", sa.String(), nullable=False, server_default=""),
+        sa.Column("origin", sa.String(), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_table(
+        "dataset_usage",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("dataset_id", sa.String(length=36), sa.ForeignKey("datasets.id"), nullable=False),
+        sa.Column("views", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("downloads", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("api_calls", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_accessed", sa.DateTime()),
+    )
+    op.create_table(
+        "models",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("model_type", sa.String(length=50), nullable=False),
+        sa.Column("owner_id", sa.String(length=36), nullable=False),
+        sa.Column("owner_type", sa.String(length=50)),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("message", sa.String(), nullable=False),
+        sa.Column("type", sa.String(length=50), nullable=False),
+        sa.Column("is_read", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("notifications")
+    op.drop_table("models")
+    op.drop_table("dataset_usage")
+    op.drop_table("dataset_versions")
+    op.drop_table("datasets")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ yfinance
 statsmodels
 matplotlib
 Flask-SocketIO
-SQLAlchemy
-alembic
+SQLAlchemy>=2.0
+alembic>=1.11

--- a/routes/api_datasets.py
+++ b/routes/api_datasets.py
@@ -1,23 +1,33 @@
 from flask import Blueprint, jsonify
 
-bp = Blueprint("api_datasets", __name__, url_prefix="/api/datasets")
+from models import Dataset
+from models.db import SessionLocal
 
-DATASETS = [
-    {"id": 1, "name": "Dataset 1", "description": "First dataset"},
-    {"id": 2, "name": "Dataset 2", "description": "Second dataset"},
-]
+bp = Blueprint("api_datasets", __name__, url_prefix="/api/datasets")
 
 
 @bp.get("/")
 def list_datasets():
-    """Return all datasets."""
-    return jsonify(DATASETS)
+    """Return all datasets stored in the database."""
+    with SessionLocal() as session:
+        datasets = session.query(Dataset).all()
+        return jsonify(
+            [
+                {
+                    "id": d.id,
+                    "name": d.name,
+                    "description": d.description,
+                }
+                for d in datasets
+            ]
+        )
 
 
-@bp.get("/<int:dataset_id>")
-def dataset_detail(dataset_id: int):
+@bp.get("/<string:dataset_id>")
+def dataset_detail(dataset_id: str):
     """Return details for a single dataset."""
-    dataset = next((d for d in DATASETS if d["id"] == dataset_id), None)
-    if dataset is None:
-        return jsonify({"error": "Dataset not found"}), 404
-    return jsonify(dataset)
+    with SessionLocal() as session:
+        dataset = session.get(Dataset, dataset_id)
+        if dataset is None:
+            return jsonify({"error": "Dataset not found"}), 404
+        return jsonify({"id": dataset.id, "name": dataset.name, "description": dataset.description})

--- a/services/notifications.py
+++ b/services/notifications.py
@@ -1,35 +1,48 @@
-"""In-memory notification service with WebSocket push support."""
+"""Notification service backed by the database."""
 from __future__ import annotations
 
-from dataclasses import asdict
-from itertools import count
-from typing import Dict, Tuple
+from typing import Dict, Any
 
 from models import Notification
+from models.db import SessionLocal
 from ws import emit_user_notification
 
-# Simple in-memory store for notifications {id: (user_email, Notification)}
-_notifications: Dict[int, Tuple[str, Notification]] = {}
-_ids = count(1)
+
+def _to_payload(notification: Notification) -> Dict[str, Any]:
+    """Serialize a ``Notification`` instance for websocket emission."""
+
+    return {
+        "id": notification.id,
+        "message": notification.message,
+        "type": notification.type,
+        "is_read": notification.is_read,
+        "created_at": notification.created_at.isoformat(),
+    }
 
 
 def create_notification(user: str, message: str, type: str) -> Notification:
     """Create a notification for ``user`` and push it to active sessions."""
-    notification = Notification(id=next(_ids), message=message, type=type)
-    _notifications[notification.id] = (user, notification)
-    payload = asdict(notification)
-    payload["created_at"] = notification.created_at.isoformat()
-    emit_user_notification(user, payload)
+
+    with SessionLocal() as session:
+        notification = Notification(user_id=user, message=message, type=type)
+        session.add(notification)
+        session.commit()
+        session.refresh(notification)
+
+    emit_user_notification(user, _to_payload(notification))
     return notification
 
 
-def update_notification(notification_id: int, **changes) -> Notification:
+def update_notification(notification_id: str, **changes) -> Notification:
     """Update an existing notification and push changes to the user."""
-    user, notification = _notifications[notification_id]
-    for key, value in changes.items():
-        setattr(notification, key, value)
-    payload = asdict(notification)
-    payload["created_at"] = notification.created_at.isoformat()
-    emit_user_notification(user, payload)
-    return notification
 
+    with SessionLocal() as session:
+        notification = session.get(Notification, notification_id)
+        for key, value in changes.items():
+            setattr(notification, key, value)
+        session.commit()
+        session.refresh(notification)
+        user = notification.user_id
+
+    emit_user_notification(user, _to_payload(notification))
+    return notification


### PR DESCRIPTION
## Summary
- Replace dataclass scaffolds with SQLAlchemy ORM models for datasets, models, and notifications
- Configure session management and update dataset API & notification service to persist data
- Add Alembic migration creating core tables

## Testing
- `pip install -r requirements.txt`
- `alembic upgrade head`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75e6ebd148329a61422240be51a83