### PR TITLE
Display specification overview and public catalog data on homepage

### DIFF
--- a/routes/docs.py
+++ b/routes/docs.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from flask import Blueprint, render_template, abort
+
+bp = Blueprint("docs", __name__, url_prefix="/docs")
+
+
+@bp.get("/specification/<path:page>")
+def specification(page: str):
+    """Serve markdown files from docs/specification as simple pages."""
+    md_path = Path("docs/specification") / f"{page}.md"
+    if not md_path.exists():
+        abort(404)
+    content = md_path.read_text(encoding="utf-8")
+    return render_template("docs/markdown.html", content=content)

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,16 @@
     <header class="bg-gray-800 text-white">
       <nav class="container mx-auto flex items-center justify-between p-4">
         <a href="/" class="text-lg font-bold">Economical</a>
-        <div class="space-x-4">
+        <div class="flex items-center space-x-4">
+          <div class="relative group">
+            <a href="#" class="hover:underline">Docs</a>
+            <div class="absolute hidden group-hover:block bg-white text-black mt-2 rounded shadow-lg">
+              <span class="block px-4 py-2 font-semibold">Specification</span>
+              <a href="/docs/specification/my_account" class="block px-4 py-2 hover:bg-gray-200">My Account</a>
+              <a href="/docs/specification/dataset_catalog" class="block px-4 py-2 hover:bg-gray-200">Dataset Catalog</a>
+              <a href="/docs/specification/model_catalog" class="block px-4 py-2 hover:bg-gray-200">Model Catalog</a>
+            </div>
+          </div>
           {% if session.get('user') %}
           <a href="{{ url_for('my_account.dashboard') }}" class="hover:underline">My Account</a>
           {% else %}

--- a/templates/docs/markdown.html
+++ b/templates/docs/markdown.html
@@ -1,0 +1,4 @@
+{% extends 'base.html' %}
+{% block content %}
+<pre class="whitespace-pre-wrap">{{ content }}</pre>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,5 +2,39 @@
 
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Economical</h1>
-<p>Welcome to the Economical platform.</p>
+
+<section class="mb-6">
+  <h2 class="text-xl font-semibold mb-2">My Account Overview</h2>
+  {% if my_account_overview %}
+  <p>{{ my_account_overview }}</p>
+  {% else %}
+  <p class="text-gray-500">Overview unavailable.</p>
+  {% endif %}
+</section>
+
+<section class="mb-6">
+  <h2 class="text-xl font-semibold mb-2">Public Datasets</h2>
+  {% if datasets %}
+  <ul class="list-disc list-inside">
+    {% for ds in datasets %}
+    <li>{{ ds.name }}</li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p class="text-gray-500">No public datasets available.</p>
+  {% endif %}
+</section>
+
+<section class="mb-6">
+  <h2 class="text-xl font-semibold mb-2">Public Models</h2>
+  {% if models %}
+  <ul class="list-disc list-inside">
+    {% for m in models %}
+    <li>{{ m.name }}</li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p class="text-gray-500">No public models available.</p>
+  {% endif %}
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show My Account specification overview and lists of public datasets and models on the homepage
- Add Docs dropdown with links to specification pages in the navigation bar
- Serve specification markdown files via a new docs blueprint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a764ebf77c832980d4651e25926a4e