### PR TITLE
feat: add model visibility column

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,11 @@ def index(path: str) -> str:
             .filter(Dataset.visibility == "public")
             .all()
         )
-        models = session.query(Model).filter(Model.owner_type == "public").all()
+        models = (
+            session.query(Model)
+            .filter(Model.visibility == "public")
+            .all()
+        )
 
     return render_template(
         "index.html",

--- a/migrations/versions/0003_add_model_visibility.py
+++ b/migrations/versions/0003_add_model_visibility.py
@@ -1,0 +1,28 @@
+"""add visibility column to models"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "models",
+        sa.Column(
+            "visibility",
+            sa.String(length=50),
+            nullable=False,
+            server_default="private",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("models", "visibility")
+

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -91,6 +91,7 @@ class Model(Base):
     name = Column(String(255), nullable=False)
     description = Column(String, nullable=False)
     model_type = Column(String(50), nullable=False)
+    visibility = Column(String(50), default="private")
     owner_id = Column(String(36), nullable=False)
     owner_type = Column(String(50))
     created_at = Column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## Summary
- add visibility column to Model with default private
- filter catalog models by visibility instead of owner_type
- migrate database to include new column

## Testing
- `DATABASE_URL=sqlite:///economical.db alembic upgrade head`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76964ca58832985927a7a50868396